### PR TITLE
FEAT: 로그인 및 회원가입 

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
   timeout: 30000,
 });
 

--- a/src/features/auth/useLogin.ts
+++ b/src/features/auth/useLogin.ts
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import apiClient from '@/api/client';
+import { useAuthStore } from '@/stores/authStore';
+import type { User, UserRole } from '@/types/user';
+
+type ApiRole = 'LEADER' | 'MEMBER';
+
+const USE_MOCK_LOGIN = true;
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+interface LoginApiUser {
+  id: string | number;
+  email: string;
+  name: string;
+  role: ApiRole;
+  teamId?: string | number | null;
+}
+
+interface LoginApiResponse {
+  data?: {
+    accessToken?: string;
+    token?: string;
+    user?: LoginApiUser;
+  };
+}
+
+const toUserRole = (role: ApiRole): UserRole => (role === 'LEADER' ? 'leader' : 'member');
+
+const toUser = (user: LoginApiUser): User => ({
+  id: String(user.id),
+  email: user.email,
+  name: user.name,
+  role: toUserRole(user.role),
+  teamId: user.teamId == null ? '' : String(user.teamId),
+});
+
+export function useLogin() {
+  const setAuth = useAuthStore((state) => state.setAuth);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const login = async ({ email, password }: LoginRequest) => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      if (USE_MOCK_LOGIN) {
+        const authUser: User = {
+          id: '1',
+          email: email.trim(),
+          name: '테스트 유저',
+          role: 'leader',
+          teamId: '1',
+        };
+
+        localStorage.setItem('token', 'mock-token');
+        setAuth(authUser, 'mock-token');
+        console.log('authStore state', useAuthStore.getState());
+
+        return authUser;
+      }
+
+      const response = await apiClient.post<LoginApiResponse>('/api/v1/auth/login', {
+        email: email.trim(),
+        password,
+      });
+      const loginData = response.data.data;
+      const user = loginData?.user;
+      const token = loginData?.accessToken || loginData?.token || '';
+
+      if (!user || !token || (user.role !== 'LEADER' && user.role !== 'MEMBER')) {
+        throw new Error('Invalid login response');
+      }
+
+      const authUser = toUser(user);
+      localStorage.setItem('token', token);
+      setAuth(authUser, token);
+
+      return authUser;
+    } catch {
+      const message = '이메일 또는 비밀번호가 올바르지 않습니다';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { login, isLoading, error };
+}

--- a/src/features/auth/useSignup.ts
+++ b/src/features/auth/useSignup.ts
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import apiClient from '@/api/client';
+import { useAuthStore } from '@/stores/authStore';
+import type { User, UserRole } from '@/types/user';
+
+export type SignupRole = 'LEADER' | 'MEMBER';
+
+const USE_MOCK_SIGNUP = true;
+
+interface SignupRequest {
+  name: string;
+  email: string;
+  password: string;
+  role: SignupRole;
+  jobTitle?: string;
+}
+
+interface SignupApiUser {
+  id: string | number;
+  email: string;
+  name: string;
+  role: SignupRole;
+  jobTitle?: string | null;
+  teamId?: string | number | null;
+}
+
+interface SignupApiResponse {
+  success?: boolean;
+  message?: string;
+  data?: {
+    accessToken?: string;
+    token?: string;
+    user?: SignupApiUser;
+  };
+}
+
+const toUserRole = (role: SignupRole): UserRole => (role === 'LEADER' ? 'leader' : 'member');
+
+const toUser = (user: SignupApiUser): User => ({
+  id: String(user.id),
+  email: user.email,
+  name: user.name,
+  role: toUserRole(user.role),
+  teamId: user.teamId == null ? '' : String(user.teamId),
+});
+
+export function useSignup() {
+  const setAuth = useAuthStore((state) => state.setAuth);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const signup = async ({ name, email, password, role, jobTitle }: SignupRequest) => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const signupPayload = {
+        name: name.trim(),
+        email: email.trim(),
+        password,
+        role,
+        ...(jobTitle?.trim() ? { jobTitle: jobTitle.trim() } : {}),
+      };
+
+      console.log('signup payload', signupPayload);
+
+      if (USE_MOCK_SIGNUP) {
+        return null;
+      }
+
+      const response = await apiClient.post<SignupApiResponse>('/api/v1/auth/signup', signupPayload);
+
+      if (response.data?.success === false) {
+        throw new Error(response.data.message || '회원 가입에 실패했습니다.');
+      }
+
+      const signupData = response.data.data;
+      const user = signupData?.user;
+      const token = signupData?.accessToken || signupData?.token || '';
+
+      if (user && token) {
+        const authUser = toUser(user);
+        localStorage.setItem('token', token);
+        setAuth(authUser, token);
+        return authUser;
+      }
+
+      return null;
+    } catch {
+      const message = '회원 가입에 실패했습니다.';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { signup, isLoading, error };
+}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,3 +1,76 @@
+import { type FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { useLogin } from '@/features/auth/useLogin';
+
 export default function LoginPage() {
-  return <div className="flex items-center justify-center h-screen"><p>Login Page</p></div>;
+  const navigate = useNavigate();
+  const { login, isLoading } = useLogin();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage('');
+
+    if (!email.trim() || !password) {
+      setErrorMessage('이메일 또는 비밀번호가 올바르지 않습니다');
+      return;
+    }
+
+    try {
+      const user = await login({ email, password });
+      navigate(user.role === 'leader' ? '/leader/dashboard' : '/member/dashboard');
+    } catch {
+      setErrorMessage('이메일 또는 비밀번호가 올바르지 않습니다');
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6">
+      <section className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <h1 className="text-4xl font-bold tracking-normal text-black">READB</h1>
+          <p className="mt-4 text-sm text-gray-500">
+            아직 계정이 없으신가요?{' '}
+            <Link to="/signup" className="font-medium text-black underline-offset-4 hover:underline">
+              회원가입
+            </Link>
+          </p>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">이메일</span>
+            <Input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="이메일을 입력하세요"
+              autoComplete="email"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">비밀번호</span>
+            <Input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="비밀번호를 입력하세요"
+              autoComplete="current-password"
+            />
+          </label>
+
+          {errorMessage && <p className="text-sm text-red-600">{errorMessage}</p>}
+
+          <Button type="submit" className="mt-2 w-full" disabled={isLoading}>
+            {isLoading ? '로그인 중...' : '로그인'}
+          </Button>
+        </form>
+      </section>
+    </main>
+  );
 }

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -1,3 +1,204 @@
+import { type FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { useSignup, type SignupRole } from '@/features/auth/useSignup';
+
+type Role = SignupRole;
+
+interface SignupForm {
+  name: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  role: Role | '';
+  jobTitle: string;
+}
+
+const initialForm: SignupForm = {
+  name: '',
+  email: '',
+  password: '',
+  passwordConfirm: '',
+  role: '',
+  jobTitle: '',
+};
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const roleOptions: Array<{ label: string; value: Role }> = [
+  { label: '리더', value: 'LEADER' },
+  { label: '멤버', value: 'MEMBER' },
+];
+
 export default function SignupPage() {
-  return <div className="flex items-center justify-center h-screen"><p>Signup Page</p></div>;
+  const navigate = useNavigate();
+  const { signup, isLoading } = useSignup();
+  const [form, setForm] = useState<SignupForm>(initialForm);
+  const [message, setMessage] = useState('');
+  const [messageType, setMessageType] = useState<'success' | 'error' | null>(null);
+
+  const updateField = (field: keyof SignupForm, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setMessage('');
+    setMessageType(null);
+  };
+
+  const validateForm = () => {
+    const { name, email, password, passwordConfirm, role } = form;
+
+    if (!name.trim() || !email.trim() || !password || !passwordConfirm || !role) {
+      return '모든 내용을 입력해주세요.';
+    }
+
+    if (!emailPattern.test(email.trim())) {
+      return '올바른 이메일 형식을 입력해주세요.';
+    }
+
+    if (password !== passwordConfirm) {
+      return '비밀번호와 비밀번호 확인 내용이 일치하지 않습니다.';
+    }
+
+    return '';
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const validationMessage = validateForm();
+    if (validationMessage) {
+      setMessage(validationMessage);
+      setMessageType('error');
+      return;
+    }
+
+    setMessage('');
+    setMessageType(null);
+
+    try {
+      if (!form.role) {
+        throw new Error('Role is required');
+      }
+
+      await signup({
+        name: form.name.trim(),
+        email: form.email.trim(),
+        password: form.password,
+        role: form.role,
+        jobTitle: form.jobTitle,
+      });
+
+      setMessage('가입이 성공하였습니다!');
+      setMessageType('success');
+      window.setTimeout(() => navigate('/login'), 1000);
+    } catch (error) {
+      const serverMessage =
+        error && typeof error === 'object' && 'response' in error
+          ? (error.response as { data?: { message?: string } })?.data?.message
+          : '';
+
+      setMessage(serverMessage || '회원 가입에 실패했습니다.');
+      setMessageType('error');
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6 py-10">
+      <section className="w-full max-w-sm">
+        <h1 className="mb-8 text-center text-3xl font-bold tracking-normal text-black">회원가입</h1>
+
+        <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">이름</span>
+            <Input
+              type="text"
+              value={form.name}
+              onChange={(event) => updateField('name', event.target.value)}
+              placeholder="이름을 입력하세요"
+              autoComplete="name"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">이메일</span>
+            <Input
+              type="email"
+              value={form.email}
+              onChange={(event) => updateField('email', event.target.value)}
+              placeholder="이메일을 입력하세요"
+              autoComplete="email"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">비밀번호</span>
+            <Input
+              type="password"
+              value={form.password}
+              onChange={(event) => updateField('password', event.target.value)}
+              placeholder="비밀번호를 입력하세요"
+              autoComplete="new-password"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">비밀번호 확인</span>
+            <Input
+              type="password"
+              value={form.passwordConfirm}
+              onChange={(event) => updateField('passwordConfirm', event.target.value)}
+              placeholder="비밀번호를 다시 입력하세요"
+              autoComplete="new-password"
+            />
+          </label>
+
+          <fieldset>
+            <legend className="mb-2 block text-sm font-medium text-gray-800">역할 선택</legend>
+            <div className="grid grid-cols-2 gap-2">
+              {roleOptions.map((role) => (
+                <label
+                  key={role.value}
+                  className={`flex cursor-pointer items-center justify-center rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${
+                    form.role === role.value
+                      ? 'border-black bg-black text-white'
+                      : 'border-gray-200 bg-white text-gray-700 hover:border-gray-400'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="role"
+                    value={role.value}
+                    checked={form.role === role.value}
+                    onChange={() => updateField('role', role.value)}
+                    className="sr-only"
+                  />
+                  {role.label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">직무</span>
+            <Input
+              type="text"
+              value={form.jobTitle}
+              onChange={(event) => updateField('jobTitle', event.target.value)}
+              placeholder="직무를 입력하세요"
+              autoComplete="organization-title"
+            />
+          </label>
+
+          {message && (
+            <p className={`text-sm ${messageType === 'success' ? 'text-green-600' : 'text-red-600'}`}>
+              {message}
+            </p>
+          )}
+
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? '가입 중...' : '가입하기'}
+          </Button>
+        </form>
+      </section>
+    </main>
+  );
 }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -9,14 +9,8 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  user: {
-    id: 'u1',
-    name: 'Guest',
-    email: 'guest@readb.io',
-    role: 'leader',
-    avatarInitials: 'G',
-  },
-  token: 'mock-token',
+  user: null,
+  token: localStorage.getItem('token'),
   setAuth: (user, token) => set({ user, token }),
   clearAuth: () => set({ user: null, token: null }),
 }));


### PR DESCRIPTION
### **작업 내용**
- 로그인 및 회원 가입 구현 (mock 이용) 

### **참고 사항**
- useLogin.ts 
    - USE_MOCK_LOGIN = true → mock 데이터 활용하여 로그인 (리더)
    - USE_MOCK_LOGIN = false → mock 데이터 활용 X 
     ** 백엔드 연결 이후 이 부분 false로 유지하거나 코드 아예 제거 

- useSignup.ts
   - USE_MOCK_SIGNUP 이용 
