### PR TITLE
feat: 미팅 상세 페이지 역할 분리 및 백엔드 API 연동

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,215 +1,81 @@
-# ReadB Client — Frontend CLAUDE.md
+# CLAUDE.md
 
-## Project Definition
-ReadB is a frontend client for a B2B HR SaaS that quantifies the Honesty Gap in 1-on-1 meetings using AI.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Tech Stack
-- React 18 + TypeScript 5
-- Vite (build)
-- Tailwind CSS + shadcn/ui (UI)
-- Recharts (charts: Silent Risk Radar)
-- react-wordcloud (Blocker Cloud)
-- React Router v6 (routing)
-- Axios (API calls)
-- Zustand (global state: auth tokens, user info)
-- Vercel (deployment)
+## Project Overview
 
-## Directory Structure + Ownership
+ReadB is a B2B HR SaaS frontend that quantifies the "Honesty Gap" in 1-on-1 meetings using AI. It serves two user roles: **leader** (리더) and **member** (멤버).
 
-```
-src/
-│
-├── app/                         # [Shared] App entry point
-│   ├── App.tsx                      ← Shared (routing definitions led by FE1)
-│   ├── router.tsx                   ← FE1 only
-│   └── providers.tsx                ← FE2 initial setup (Theme, QueryClient, etc.)
-│
-├── components/                  # [FE2 only — Shared component library]
-│   ├── ui/                          ← FE2 only (shadcn/ui customization)
-│   │   ├── Button.tsx
-│   │   ├── Card.tsx
-│   │   ├── Badge.tsx
-│   │   ├── Modal.tsx
-│   │   ├── Accordion.tsx
-│   │   ├── Skeleton.tsx
-│   │   └── Input.tsx
-│   ├── charts/                      ← FE2 only
-│   │   ├── ScatterRadar.tsx             (Silent Risk Radar)
-│   │   ├── BlockerCloud.tsx             (Blocker Cloud word cloud)
-│   │   └── GapScoreGauge.tsx            (Gap Score visualization)
-│   ├── feedback/                    ← FE2 only
-│   │   ├── FeedbackCard.tsx             (Feedback card accordion)
-│   │   └── FeedbackCardList.tsx
-│   ├── loading/                     ← FE2 only
-│   │   ├── AnalysisLoading.tsx          (Witty loading UX)
-│   │   └── loadingCopies.ts             (Leader/member copywriting data)
-│   └── layout/                      ← FE2 only
-│       ├── Sidebar.tsx
-│       ├── Header.tsx
-│       └── PageLayout.tsx
-│
-├── pages/                       # [FE1 only — Page-level screens]
-│   ├── auth/                        ← FE1 only
-│   │   ├── LoginPage.tsx
-│   │   └── SignupPage.tsx
-│   ├── leader/                      ← FE1 only
-│   │   ├── LeaderDashboard.tsx          (Radar + Cloud + Summary)
-│   │   ├── MeetingDetailPage.tsx        (Recording + Analysis results)
-│   │   └── PromiseLedgerPage.tsx        (Promise ledger)
-│   └── member/                      ← FE1 only
-│       ├── MemberDashboard.tsx          (Career Memory timeline)
-│       ├── MeetingFeedbackPage.tsx      (Coaching feedback cards)
-│       └── SurveyPage.tsx               (Pre-meeting survey form)
-│
-├── features/                    # [Domain-specific logic used within pages]
-│   ├── auth/                        ← FE1 only
-│   │   ├── useLogin.ts
-│   │   └── useSignup.ts
-│   ├── meeting/                     ← FE1 only
-│   │   ├── useRecorder.ts               (MediaRecorder hook)
-│   │   ├── useUploadRecording.ts
-│   │   ├── useMeetingStatus.ts          (Polling hook)
-│   │   └── useAnalysisResult.ts
-│   ├── leader/                      ← FE1 only
-│   │   ├── useRadarData.ts
-│   │   ├── useBlockerData.ts
-│   │   └── usePromises.ts
-│   ├── member/                      ← FE1 only
-│   │   ├── useCareerMemory.ts
-│   │   ├── useFeedbackCards.ts
-│   │   └── useSurvey.ts
-│   └── common/                      ← Shared (additions only, no modifications to existing code)
-│       └── useAuth.ts
-│
-├── api/                         # [Shared — Strict rules apply]
-│   ├── client.ts                    ← FE2 initial setup (Axios instance + interceptors)
-│   ├── auth.api.ts                  ← FE1
-│   ├── meeting.api.ts               ← FE1
-│   ├── survey.api.ts                ← FE1
-│   ├── analysis.api.ts              ← FE1
-│   └── types.ts                     ← Shared (API response types, additions only)
-│
-├── stores/                      # [FE2 initial setup, shared afterwards]
-│   └── authStore.ts                 ← FE2 initial, modifications require mutual agreement
-│
-├── styles/                      # [FE2 only]
-│   └── globals.css
-│
-├── constants/                   # [Shared — Additions only, no modifications to existing code]
-│   └── routes.ts                    (Route path constants)
-│
-└── types/                       # [Shared — Additions only, no modifications to existing code]
-    ├── user.ts
-    ├── meeting.ts
-    ├── analysis.ts
-    └── promise.ts
-```
+## Commands
 
-## Team Role Summary
-
-### FE1 (Pages + Business Logic)
-- Ownership: All pages/*, features/*, api/ functions, routing
-- Core responsibilities: Login/signup flow, recording screen (MediaRecorder), leader/member dashboards, analysis result screens, survey forms
-- Working principle: Only imports and uses components from components/. Never creates them directly. Requests FE2 for any needed shared components.
-
-### FE2 (Design System + Data Visualization)
-- Ownership: components/*, stores/*, styles/*, initial setup (providers, client)
-- Core responsibilities: shadcn/ui customization, charts (ScatterRadar, BlockerCloud), feedback card accordion, loading UX, layout shell
-- Working principle: Never modifies files in pages/. Components receive data via props and only render. No data-fetching logic inside components.
-
-## Conflict Prevention Rules
-
-1. **Absolute Boundary**: FE1 must not modify files inside the components/ folder. FE2 must not modify files inside the pages/ folder. Following this single rule eliminates 90% of conflicts.
-
-2. **Component ↔ Page Communication via Props Only**: Components built by FE2 must export a Props interface. FE1 injects data according to those Props. Components must not call APIs directly.
-
-   ```typescript
-   // Built by FE2 (components/charts/ScatterRadar.tsx)
-   interface ScatterRadarProps {
-     data: { memberId: string; name: string; surfaceScore: number; inferredScore: number }[];
-     onMemberClick?: (memberId: string) => void;
-   }
-   export default function ScatterRadar({ data, onMemberClick }: ScatterRadarProps) { ... }
-
-   // Used by FE1 (pages/leader/LeaderDashboard.tsx)
-   const { data } = useRadarData(teamId);
-   return <ScatterRadar data={data} onMemberClick={handleClick} />;
-   ```
-
-3. **types/ and constants/ Addition Rules**: Adding new types/constants is free. Renaming or deleting fields of existing types requires notification via Slack/Discord first.
-
-4. **api/types.ts Rules**: BE API response types are defined here. When BE API specs change, FE1 updates this file → FE2 pulls and reflects changes in component Props.
-
-5. **Branch Naming**: `feat/fe1-recording-page`, `feat/fe2-scatter-radar` — prefix indicates ownership.
-
-6. **Shared File Modifications**: When changes to App.tsx, api/client.ts, stores/authStore.ts, or types/ are needed, always notify the other party first, merge that PR first, then the other party rebases.
-
-## Routing Structure
-
-```typescript
-// Managed by FE1 (app/router.tsx)
-const routes = [
-  { path: '/login',                    element: <LoginPage /> },
-  { path: '/signup',                   element: <SignupPage /> },
-  { path: '/leader/dashboard',         element: <LeaderDashboard /> },
-  { path: '/leader/meeting/:meetingId', element: <MeetingDetailPage /> },
-  { path: '/leader/promises',          element: <PromiseLedgerPage /> },
-  { path: '/member/dashboard',         element: <MemberDashboard /> },
-  { path: '/member/meeting/:meetingId', element: <MeetingFeedbackPage /> },
-  { path: '/member/survey/:meetingId', element: <SurveyPage /> },
-];
-```
-
-## Component Development Order (FE2 Reference)
-
-```
-Week 1: Button, Card, Badge, Input, Modal, Skeleton, PageLayout, Sidebar, Header
-         → Ready for FE1 to scaffold page structures immediately
-
-Week 2: Accordion (for feedback cards), AnalysisLoading (witty loading UX)
-         ScatterRadar, BlockerCloud, GapScoreGauge
-         → Ready for FE1 to plug into result screens
-
-Week 3~4: Polishing, responsive design, animations, edge case handling
-```
-
-## Loading UX Copy Structure (FE2 Reference)
-
-```typescript
-// components/loading/loadingCopies.ts
-export const loadingSteps = [
-  { step: 1, label: 'Converting conversation to text', icon: '🎧' },
-  { step: 2, label: 'Reading between the lines', icon: '🔍' },
-  { step: 3, label: 'Crunching the numbers', icon: '📊' },
-  { step: 4, label: 'Polishing the feedback', icon: '💡' },
-];
-
-export const witCopies = {
-  leader: [
-    'Checking if "I\'m fine" really means fine...',
-    'Surfacing hidden blockers onto the word cloud...',
-    'Being careful not to ding your leadership score...',
-  ],
-  member: [
-    'Finding strengths your leader might have missed...',
-    'Recording today\'s growth in your Career Memory...',
-    'Picking the perfect one-liner for your next meeting...',
-  ],
-};
-```
-
-## Development Commands
 ```bash
-npm run dev          # Local dev server (Vite, http://localhost:5173)
-npm run build        # Production build
-npm run preview      # Preview build output locally
-npm run lint         # ESLint
+npm run dev          # Vite dev server at http://localhost:5173
+npm run build        # tsc + vite build
+npm run lint         # ESLint on src/**/*.{ts,tsx}
 npm run type-check   # tsc --noEmit
 ```
 
-## Important Notes
-- MediaRecorder mimeType: Use `audio/webm;codecs=opus` (excellent compression, good browser compatibility)
-- Recording Blob is sent via FormData: `Content-Type: multipart/form-data`
-- Analysis polling interval: 3 seconds (`useMeetingStatus` hook with setInterval 3000ms)
-- Polling timeout: Show error screen if exceeding 3 minutes
-- When modifying shadcn/ui components, preserve the original and wrap with a wrapper component (for update compatibility)
+Environment variable required: `VITE_API_BASE_URL` (defaults to `http://localhost:8080`).
+
+## Architecture
+
+### Two-team Ownership Model
+
+**FE1** owns `pages/`, `features/`, `api/` functions, and routing. Pages consume components via props only — no component API calls.
+
+**FE2** owns `components/`, `stores/` initial setup, `styles/`. Components are pure renderers: they export a Props interface and receive all data from outside.
+
+Boundary rule: FE1 never touches `components/`; FE2 never touches `pages/`.
+
+### State Management
+
+Two Zustand stores:
+- `stores/authStore.ts` — `user`, `token`, `setAuth`, `clearAuth`. Token is also mirrored to `localStorage` and read directly by `api/client.ts` on every request.
+- `stores/meetingStore.ts` — client-side meeting list, `createMeeting`, `updateMeetingStatus`, `setRecordingDuration`, modal open state. Meetings are created in-memory (no persistence).
+
+### API Client
+
+`api/client.ts` is an Axios instance that reads `localStorage.getItem('token')` directly (not from Zustand) for Authorization headers. Base URL from `VITE_API_BASE_URL`.
+
+### Meeting Recording Flow
+
+`MeetingDetailPage` orchestrates the full recording lifecycle:
+1. `useRecorder` — wraps `MediaRecorder` + Web Audio API for waveform level. Records as `audio/webm`. Blob is held in a ref until `stop()`.
+2. `useUploadRecording` — posts blob as `FormData` to `/meetings/upload`. **Currently a stub** (API call is commented out).
+3. `useMeetingStatus` — polls BE for `analyzing → completed` transition every 3s. **Currently a stub** (20s demo timer, polling logic commented out).
+
+Meeting status progression: `pending → recording → analyzing → completed`.
+
+### Path Aliases
+
+`@/` maps to `src/` (configured in Vite). Always use `@/` imports, never relative `../` across directories.
+
+## Key Structural Decisions
+
+- **`components/blocker/`** — Three sub-components (`BlockerActionList`, `BlockerDetailCard`, `BlockerSummaryNote`) that compose into the blocker analysis view. Distinct from `components/charts/BlockerCloud`.
+- **`components/ui/`** wraps shadcn/ui primitives. When customizing, wrap the original rather than modifying it in place.
+- **`data/mockRadarData.ts`** — Dummy data used for the radar chart until the real API is wired. Remove when `useRadarData` connects to BE.
+- **`types/meeting.ts`** has two overlapping shapes: `Meeting` (API shape) and `MeetingData` (client store shape). `MeetingData` is what the store and pages use.
+
+## Routes
+
+```
+/                         → redirect to /leader/dashboard
+/login, /signup
+/leader/dashboard         LeaderDashboard
+/leader/meetings          MeetingsPage
+/leader/meeting/:id       MeetingDetailPage
+/leader/promises          PromiseLedgerPage
+/member/dashboard         MemberDashboard
+/member/meeting/:id       MeetingFeedbackPage
+/member/survey/:id        SurveyPage
+/meeting                  MeetingDetailPage (no :id)
+/leader/reports, /leader/9box, /leader/overview, /settings, /invite → all stub to LeaderDashboard
+```
+
+## Shared File Rules
+
+- `types/` and `constants/` — additions only; renames/deletes require team notification.
+- `api/types.ts` — BE response shapes go here; `ApiResponse<T>` is the standard wrapper.
+- `App.tsx`, `api/client.ts`, `stores/authStore.ts` — notify other team before modifying; merge that PR first, then rebase.
+- Branch naming: `feat/fe1-<feature>` or `feat/fe2-<feature>`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,215 @@
+# ReadB Client — Frontend CLAUDE.md
+
+## Project Definition
+ReadB is a frontend client for a B2B HR SaaS that quantifies the Honesty Gap in 1-on-1 meetings using AI.
+
+## Tech Stack
+- React 18 + TypeScript 5
+- Vite (build)
+- Tailwind CSS + shadcn/ui (UI)
+- Recharts (charts: Silent Risk Radar)
+- react-wordcloud (Blocker Cloud)
+- React Router v6 (routing)
+- Axios (API calls)
+- Zustand (global state: auth tokens, user info)
+- Vercel (deployment)
+
+## Directory Structure + Ownership
+
+```
+src/
+│
+├── app/                         # [Shared] App entry point
+│   ├── App.tsx                      ← Shared (routing definitions led by FE1)
+│   ├── router.tsx                   ← FE1 only
+│   └── providers.tsx                ← FE2 initial setup (Theme, QueryClient, etc.)
+│
+├── components/                  # [FE2 only — Shared component library]
+│   ├── ui/                          ← FE2 only (shadcn/ui customization)
+│   │   ├── Button.tsx
+│   │   ├── Card.tsx
+│   │   ├── Badge.tsx
+│   │   ├── Modal.tsx
+│   │   ├── Accordion.tsx
+│   │   ├── Skeleton.tsx
+│   │   └── Input.tsx
+│   ├── charts/                      ← FE2 only
+│   │   ├── ScatterRadar.tsx             (Silent Risk Radar)
+│   │   ├── BlockerCloud.tsx             (Blocker Cloud word cloud)
+│   │   └── GapScoreGauge.tsx            (Gap Score visualization)
+│   ├── feedback/                    ← FE2 only
+│   │   ├── FeedbackCard.tsx             (Feedback card accordion)
+│   │   └── FeedbackCardList.tsx
+│   ├── loading/                     ← FE2 only
+│   │   ├── AnalysisLoading.tsx          (Witty loading UX)
+│   │   └── loadingCopies.ts             (Leader/member copywriting data)
+│   └── layout/                      ← FE2 only
+│       ├── Sidebar.tsx
+│       ├── Header.tsx
+│       └── PageLayout.tsx
+│
+├── pages/                       # [FE1 only — Page-level screens]
+│   ├── auth/                        ← FE1 only
+│   │   ├── LoginPage.tsx
+│   │   └── SignupPage.tsx
+│   ├── leader/                      ← FE1 only
+│   │   ├── LeaderDashboard.tsx          (Radar + Cloud + Summary)
+│   │   ├── MeetingDetailPage.tsx        (Recording + Analysis results)
+│   │   └── PromiseLedgerPage.tsx        (Promise ledger)
+│   └── member/                      ← FE1 only
+│       ├── MemberDashboard.tsx          (Career Memory timeline)
+│       ├── MeetingFeedbackPage.tsx      (Coaching feedback cards)
+│       └── SurveyPage.tsx               (Pre-meeting survey form)
+│
+├── features/                    # [Domain-specific logic used within pages]
+│   ├── auth/                        ← FE1 only
+│   │   ├── useLogin.ts
+│   │   └── useSignup.ts
+│   ├── meeting/                     ← FE1 only
+│   │   ├── useRecorder.ts               (MediaRecorder hook)
+│   │   ├── useUploadRecording.ts
+│   │   ├── useMeetingStatus.ts          (Polling hook)
+│   │   └── useAnalysisResult.ts
+│   ├── leader/                      ← FE1 only
+│   │   ├── useRadarData.ts
+│   │   ├── useBlockerData.ts
+│   │   └── usePromises.ts
+│   ├── member/                      ← FE1 only
+│   │   ├── useCareerMemory.ts
+│   │   ├── useFeedbackCards.ts
+│   │   └── useSurvey.ts
+│   └── common/                      ← Shared (additions only, no modifications to existing code)
+│       └── useAuth.ts
+│
+├── api/                         # [Shared — Strict rules apply]
+│   ├── client.ts                    ← FE2 initial setup (Axios instance + interceptors)
+│   ├── auth.api.ts                  ← FE1
+│   ├── meeting.api.ts               ← FE1
+│   ├── survey.api.ts                ← FE1
+│   ├── analysis.api.ts              ← FE1
+│   └── types.ts                     ← Shared (API response types, additions only)
+│
+├── stores/                      # [FE2 initial setup, shared afterwards]
+│   └── authStore.ts                 ← FE2 initial, modifications require mutual agreement
+│
+├── styles/                      # [FE2 only]
+│   └── globals.css
+│
+├── constants/                   # [Shared — Additions only, no modifications to existing code]
+│   └── routes.ts                    (Route path constants)
+│
+└── types/                       # [Shared — Additions only, no modifications to existing code]
+    ├── user.ts
+    ├── meeting.ts
+    ├── analysis.ts
+    └── promise.ts
+```
+
+## Team Role Summary
+
+### FE1 (Pages + Business Logic)
+- Ownership: All pages/*, features/*, api/ functions, routing
+- Core responsibilities: Login/signup flow, recording screen (MediaRecorder), leader/member dashboards, analysis result screens, survey forms
+- Working principle: Only imports and uses components from components/. Never creates them directly. Requests FE2 for any needed shared components.
+
+### FE2 (Design System + Data Visualization)
+- Ownership: components/*, stores/*, styles/*, initial setup (providers, client)
+- Core responsibilities: shadcn/ui customization, charts (ScatterRadar, BlockerCloud), feedback card accordion, loading UX, layout shell
+- Working principle: Never modifies files in pages/. Components receive data via props and only render. No data-fetching logic inside components.
+
+## Conflict Prevention Rules
+
+1. **Absolute Boundary**: FE1 must not modify files inside the components/ folder. FE2 must not modify files inside the pages/ folder. Following this single rule eliminates 90% of conflicts.
+
+2. **Component ↔ Page Communication via Props Only**: Components built by FE2 must export a Props interface. FE1 injects data according to those Props. Components must not call APIs directly.
+
+   ```typescript
+   // Built by FE2 (components/charts/ScatterRadar.tsx)
+   interface ScatterRadarProps {
+     data: { memberId: string; name: string; surfaceScore: number; inferredScore: number }[];
+     onMemberClick?: (memberId: string) => void;
+   }
+   export default function ScatterRadar({ data, onMemberClick }: ScatterRadarProps) { ... }
+
+   // Used by FE1 (pages/leader/LeaderDashboard.tsx)
+   const { data } = useRadarData(teamId);
+   return <ScatterRadar data={data} onMemberClick={handleClick} />;
+   ```
+
+3. **types/ and constants/ Addition Rules**: Adding new types/constants is free. Renaming or deleting fields of existing types requires notification via Slack/Discord first.
+
+4. **api/types.ts Rules**: BE API response types are defined here. When BE API specs change, FE1 updates this file → FE2 pulls and reflects changes in component Props.
+
+5. **Branch Naming**: `feat/fe1-recording-page`, `feat/fe2-scatter-radar` — prefix indicates ownership.
+
+6. **Shared File Modifications**: When changes to App.tsx, api/client.ts, stores/authStore.ts, or types/ are needed, always notify the other party first, merge that PR first, then the other party rebases.
+
+## Routing Structure
+
+```typescript
+// Managed by FE1 (app/router.tsx)
+const routes = [
+  { path: '/login',                    element: <LoginPage /> },
+  { path: '/signup',                   element: <SignupPage /> },
+  { path: '/leader/dashboard',         element: <LeaderDashboard /> },
+  { path: '/leader/meeting/:meetingId', element: <MeetingDetailPage /> },
+  { path: '/leader/promises',          element: <PromiseLedgerPage /> },
+  { path: '/member/dashboard',         element: <MemberDashboard /> },
+  { path: '/member/meeting/:meetingId', element: <MeetingFeedbackPage /> },
+  { path: '/member/survey/:meetingId', element: <SurveyPage /> },
+];
+```
+
+## Component Development Order (FE2 Reference)
+
+```
+Week 1: Button, Card, Badge, Input, Modal, Skeleton, PageLayout, Sidebar, Header
+         → Ready for FE1 to scaffold page structures immediately
+
+Week 2: Accordion (for feedback cards), AnalysisLoading (witty loading UX)
+         ScatterRadar, BlockerCloud, GapScoreGauge
+         → Ready for FE1 to plug into result screens
+
+Week 3~4: Polishing, responsive design, animations, edge case handling
+```
+
+## Loading UX Copy Structure (FE2 Reference)
+
+```typescript
+// components/loading/loadingCopies.ts
+export const loadingSteps = [
+  { step: 1, label: 'Converting conversation to text', icon: '🎧' },
+  { step: 2, label: 'Reading between the lines', icon: '🔍' },
+  { step: 3, label: 'Crunching the numbers', icon: '📊' },
+  { step: 4, label: 'Polishing the feedback', icon: '💡' },
+];
+
+export const witCopies = {
+  leader: [
+    'Checking if "I\'m fine" really means fine...',
+    'Surfacing hidden blockers onto the word cloud...',
+    'Being careful not to ding your leadership score...',
+  ],
+  member: [
+    'Finding strengths your leader might have missed...',
+    'Recording today\'s growth in your Career Memory...',
+    'Picking the perfect one-liner for your next meeting...',
+  ],
+};
+```
+
+## Development Commands
+```bash
+npm run dev          # Local dev server (Vite, http://localhost:5173)
+npm run build        # Production build
+npm run preview      # Preview build output locally
+npm run lint         # ESLint
+npm run type-check   # tsc --noEmit
+```
+
+## Important Notes
+- MediaRecorder mimeType: Use `audio/webm;codecs=opus` (excellent compression, good browser compatibility)
+- Recording Blob is sent via FormData: `Content-Type: multipart/form-data`
+- Analysis polling interval: 3 seconds (`useMeetingStatus` hook with setInterval 3000ms)
+- Polling timeout: Show error screen if exceeding 3 minutes
+- When modifying shadcn/ui components, preserve the original and wrap with a wrapper component (for update compatibility)

--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -1,0 +1,8 @@
+import apiClient from './client';
+import type { ApiResponse } from './types';
+import type { MeetingDetail } from '@/types/meeting';
+
+export async function fetchMeetingDetail(meetingId: string): Promise<MeetingDetail> {
+  const res = await apiClient.get<ApiResponse<MeetingDetail>>(`/api/v1/meetings/${meetingId}`);
+  return res.data.data;
+}

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -3,10 +3,10 @@ import LoginPage from '@/pages/auth/LoginPage';
 import SignupPage from '@/pages/auth/SignupPage';
 import LeaderDashboard from '@/pages/leader/LeaderDashboard';
 import MeetingsPage from '@/pages/leader/MeetingsPage';
-import MeetingDetailPage from '@/pages/leader/MeetingDetailPage';
+import LeaderMeetingDetailPage from '@/pages/leader/MeetingDetailPage';
 import PromiseLedgerPage from '@/pages/leader/PromiseLedgerPage';
 import MemberDashboard from '@/pages/member/MemberDashboard';
-import MeetingFeedbackPage from '@/pages/member/MeetingFeedbackPage';
+import MemberMeetingDetailPage from '@/pages/member/MeetingDetailPage';
 import SurveyPage from '@/pages/member/SurveyPage';
 
 const router = createBrowserRouter([
@@ -15,15 +15,14 @@ const router = createBrowserRouter([
   { path: '/signup', element: <SignupPage /> },
   { path: '/leader/dashboard', element: <LeaderDashboard /> },
   { path: '/leader/meetings', element: <MeetingsPage /> },
-  { path: '/leader/meeting/:meetingId', element: <MeetingDetailPage /> },
+  { path: '/leader/meeting/:meetingId', element: <LeaderMeetingDetailPage /> },
   { path: '/leader/promises', element: <PromiseLedgerPage /> },
   { path: '/leader/reports', element: <LeaderDashboard /> },
   { path: '/leader/9box', element: <LeaderDashboard /> },
   { path: '/leader/overview', element: <LeaderDashboard /> },
   { path: '/member/dashboard', element: <MemberDashboard /> },
-  { path: '/member/meeting/:meetingId', element: <MeetingFeedbackPage /> },
+  { path: '/member/meeting/:meetingId', element: <MemberMeetingDetailPage /> },
   { path: '/member/survey/:meetingId', element: <SurveyPage /> },
-  { path: '/meeting', element: <MeetingDetailPage/> },
   { path: '/settings', element: <LeaderDashboard /> },
   { path: '/invite', element: <LeaderDashboard /> },
 ]);

--- a/src/components/survey/SurveyForm.tsx
+++ b/src/components/survey/SurveyForm.tsx
@@ -12,7 +12,7 @@ const energyOptions = [
 ];
 const desiredRoleOptions = ['그냥 들어주기', '방향성 코칭', '의사결정 도움', '리소스 확보'];
 
-interface SurveyFormProps {
+export interface SurveyFormProps {
   leaderName: string;
   scheduledAt: string;
   meetingId: number;

--- a/src/components/survey/SurveyForm.tsx
+++ b/src/components/survey/SurveyForm.tsx
@@ -1,0 +1,162 @@
+import { useMemo, useState } from 'react';
+import Button from '@/components/ui/Button';
+import Card from '@/components/ui/Card';
+
+const issueOptions = ['업무 블로커', '커리어 성장', '팀 협업', '리소스 요청', '기타'];
+const energyOptions = [
+  { value: 1, icon: '😫', label: '많이 지침' },
+  { value: 2, icon: '😳', label: '조금 힘듦' },
+  { value: 3, icon: '😊', label: '보통' },
+  { value: 4, icon: '😄', label: '좋음' },
+  { value: 5, icon: '🔥', label: '최고!' },
+];
+const desiredRoleOptions = ['그냥 들어주기', '방향성 코칭', '의사결정 도움', '리소스 확보'];
+
+interface SurveyFormProps {
+  leaderName: string;
+  scheduledAt: string;
+  meetingId: number;
+}
+
+export default function SurveyForm({ leaderName, scheduledAt, meetingId }: SurveyFormProps) {
+  const [selectedIssues, setSelectedIssues] = useState<string[]>([]);
+  const [energyLevel, setEnergyLevel] = useState<number | null>(3);
+  const [desiredRoles, setDesiredRoles] = useState<string[]>([]);
+  const [message, setMessage] = useState('');
+
+  const canSubmit = selectedIssues.length > 0 && energyLevel !== null && desiredRoles.length > 0;
+
+  const selectedEnergyLabel = useMemo(
+    () => energyOptions.find((option) => option.value === energyLevel)?.label ?? '',
+    [energyLevel],
+  );
+
+  const scheduledDate = useMemo(
+    () =>
+      new Date(scheduledAt).toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'short',
+      }),
+    [scheduledAt],
+  );
+
+  const toggleValue = (value: string, values: string[], setValues: (next: string[]) => void) => {
+    setMessage('');
+    setValues(values.includes(value) ? values.filter((item) => item !== value) : [...values, value]);
+  };
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    const payload = { meetingId, issues: selectedIssues, energyLevel, desiredRoles };
+    console.log('survey payload', payload);
+    setMessage('설문이 제출되었습니다.');
+  };
+
+  return (
+    <section className="mx-auto flex w-full max-w-[560px] flex-col items-center">
+      <p className="text-sm font-bold tracking-wide text-slate-400">
+        {leaderName}님과 1on1이 예정되어 있습니다.
+      </p>
+      <h1 className="mt-5 text-center text-2xl font-bold leading-snug text-gray-900">
+        사전 설문 조사를 진행해 주세요!
+      </h1>
+      <p className="mt-4 text-center text-base tracking-wide text-slate-400">{scheduledDate}</p>
+
+      <Card className="mt-10 w-full rounded-[20px] border-gray-200 px-9 py-9 shadow-sm">
+        <div className="space-y-9">
+          <section>
+            <h2 className="text-lg font-extrabold text-gray-900">Q1. 오늘 꼭 다루고 싶은 이슈는?</h2>
+            <div className="mt-5 flex flex-wrap gap-3">
+              {issueOptions.map((issue) => {
+                const isSelected = selectedIssues.includes(issue);
+                return (
+                  <button
+                    key={issue}
+                    type="button"
+                    onClick={() => toggleValue(issue, selectedIssues, setSelectedIssues)}
+                    className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
+                      isSelected
+                        ? 'border-violet-500 bg-violet-50 text-violet-700'
+                        : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                    }`}
+                  >
+                    {issue}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-extrabold text-gray-900">Q2. 지금 나의 에너지 레벨은?</h2>
+            <div className="mt-5 grid grid-cols-5 gap-2 sm:gap-3">
+              {energyOptions.map((energy) => {
+                const isSelected = energy.value === energyLevel;
+                return (
+                  <button
+                    key={energy.value}
+                    type="button"
+                    onClick={() => { setEnergyLevel(energy.value); setMessage(''); }}
+                    className={`flex aspect-square min-h-[88px] flex-col items-center justify-center rounded-[18px] border text-center transition-colors ${
+                      isSelected
+                        ? 'border-violet-500 bg-violet-50 text-violet-700 shadow-[0_0_0_1px_rgba(139,92,246,0.9)]'
+                        : 'border-slate-200 bg-white text-slate-400 hover:border-slate-300'
+                    }`}
+                  >
+                    <span className="text-3xl leading-none">{energy.icon}</span>
+                    <span className="mt-3 text-[11px] font-bold">{energy.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-extrabold text-gray-900">Q3. 이번 미팅에서 리더에게 바라는 역할은?</h2>
+            <div className="mt-5 flex flex-wrap gap-3">
+              {desiredRoleOptions.map((role) => {
+                const isSelected = desiredRoles.includes(role);
+                return (
+                  <button
+                    key={role}
+                    type="button"
+                    onClick={() => toggleValue(role, desiredRoles, setDesiredRoles)}
+                    className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
+                      isSelected
+                        ? 'border-violet-500 bg-violet-50 text-violet-700'
+                        : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                    }`}
+                  >
+                    {role}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <div className="pt-1">
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className={`h-14 w-full text-base ${
+                canSubmit
+                  ? 'bg-gray-900 text-white hover:bg-gray-700'
+                  : 'bg-slate-100 text-slate-400 hover:bg-slate-100 disabled:opacity-100'
+              }`}
+            >
+              제출하기
+            </Button>
+            {message && <p className="mt-4 text-center text-sm font-medium text-green-600">{message}</p>}
+            <p className="mt-9 text-center text-sm text-slate-400">
+              소요시간 약 30초 <span aria-hidden="true">⏱️</span>
+            </p>
+            <span className="sr-only">현재 에너지 레벨: {selectedEnergyLabel}</span>
+          </div>
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/ui/CreateMeetingModal.tsx
+++ b/src/components/ui/CreateMeetingModal.tsx
@@ -1,12 +1,15 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useNavigate } from 'react-router-dom';
-import { useMeetingStore } from "@/stores/meetingStore";
-import type { TeamMember } from "@/types/meeting";
+import { useAuthStore } from "@/stores/authStore";
+import apiClient from "@/api/client";
+import type { ApiResponse } from "@/api/types";
 
-const MOCK_MEMBERS: TeamMember[] = [
-  { id: "1", name: "김지수", email: "jisukim34@gmail.com" },
-  { id: "2", name: "김하슬", email: "202011992@dgu.ac.kr" },
-];
+interface TeamMemberApi {
+  id: number;
+  name: string;
+  jobTitle: string;
+  role: string;
+}
 
 interface Props {
   isOpen: boolean;
@@ -14,17 +17,51 @@ interface Props {
   onCreated: () => void;
 }
 
+const getDefaultDate = () => {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};
+
+const getDefaultTime = () => {
+  const now = new Date();
+  const h = now.getHours();
+  const min = now.getMinutes();
+  if (min < 30) return `${String(h).padStart(2, "0")}:30`;
+  const nextH = h + 1;
+  if (nextH >= 24) return "23:30";
+  return `${String(nextH).padStart(2, "0")}:00`;
+};
+
+const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
+  const h = Math.floor(i / 2);
+  const m = i % 2 === 0 ? "00" : "30";
+  return `${String(h).padStart(2, "0")}:${m}`;
+});
+
 export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props) {
   const navigate = useNavigate();
-  const createMeeting = useMeetingStore((s) => s.createMeeting);
+  const user = useAuthStore((s) => s.user);
+  const [members, setMembers] = useState<TeamMemberApi[]>([]);
   const [search, setSearch] = useState("");
-  const [selected, setSelected] = useState<TeamMember | null>(null);
-  const [role, setRole] = useState<"leader" | "member">("member");
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [selected, setSelected] = useState<TeamMemberApi | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string>(getDefaultDate());
+  const [selectedTime, setSelectedTime] = useState<string>(getDefaultTime());
   const [viewMonth, setViewMonth] = useState(() => new Date());
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const filtered = MOCK_MEMBERS.filter(
-    (m) => m.name.includes(search) || m.email.includes(search)
+  useEffect(() => {
+    if (!isOpen || !user?.teamId) return;
+    apiClient
+      .get<ApiResponse<TeamMemberApi[]>>(`/api/v1/teams/${user.teamId}/members`)
+      .then((res) => setMembers(res.data.data))
+      .catch(() => setMembers([]));
+  }, [isOpen, user?.teamId]);
+
+  const filtered = members.filter(
+    (m) => m.name.includes(search) || m.jobTitle.includes(search)
   );
 
   const calDays = useMemo(() => {
@@ -43,13 +80,20 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
     return `${y}-${m}-${String(d).padStart(2, "0")}`;
   };
 
-  const canCreate = selected && selectedDate;
+  const canCreate = selected && !isSubmitting;
 
-  const handleCreate = () => {
-    if (selected && selectedDate) {
-      const meeting = createMeeting(selected, role, selectedDate);
-      onCreated(); // 부모(App.tsx)의 onClose 등을 실행
-      navigate(`/leader/meeting/${meeting.id}`); // 생성 즉시 상세 페이지로 이동
+  const handleCreate = async () => {
+    if (!selected) return;
+    setIsSubmitting(true);
+    try {
+      const res = await apiClient.post<ApiResponse<{ meetingId: number }>>(
+        "/api/v1/meetings",
+        { memberId: selected.id, scheduledAt: `${selectedDate}T${selectedTime}:00` }
+      );
+      onCreated();
+      navigate(`/leader/meeting/${res.data.data.meetingId}`);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -93,38 +137,11 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
                   </div>
                   <div>
                     <p className="text-sm font-medium">{m.name}</p>
-                    <p className="text-xs text-gray-400">{m.email}</p>
+                    <p className="text-xs text-gray-400">{m.jobTitle}</p>
                   </div>
                 </label>
               ))}
             </div>
-
-            <p className="font-semibold mb-3">리더를 선택해주세요.</p>
-            <div className="flex gap-3">
-              {(["leader", "member"] as const).map((r) => (
-                <label
-                  key={r}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-full border cursor-pointer transition-colors ${
-                    role === r
-                      ? "border-[#4E62E6] bg-[#5F74FA]/10 text-[#5F74FA]"
-                      : "border-gray-200"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="role"
-                    checked={role === r}
-                    onChange={() => setRole(r)}
-                    className="hidden"
-                  />
-                  {r === "leader" ? "나" : "상대방"}
-                </label>
-              ))}
-            </div>
-            <p className="text-xs text-gray-400 mt-2">
-              ※ 리더는 시작·종료 권한과 상대의 업무 몰입도 및 상황 만족도 체크, 1on1 분석
-              인사이트를 제공받게 됩니다.
-            </p>
           </div>
 
           {/* 오른쪽: 캘린더 */}
@@ -179,6 +196,18 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
                   );
                 })}
               </div>
+            </div>
+            <div className="mt-4">
+              <p className="font-semibold mb-2 text-sm">미팅 시간</p>
+              <select
+                value={selectedTime}
+                onChange={(e) => setSelectedTime(e.target.value)}
+                className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-[#4E62E6]"
+              >
+                {TIME_OPTIONS.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
             </div>
           </div>
         </div>

--- a/src/features/meeting/useMeetingDetail.ts
+++ b/src/features/meeting/useMeetingDetail.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { fetchMeetingDetail } from '@/api/meetings';
+import type { MeetingDetail } from '@/types/meeting';
+
+export function useMeetingDetail(meetingId: string | undefined) {
+  const [meeting, setMeeting] = useState<MeetingDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!meetingId) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    fetchMeetingDetail(meetingId)
+      .then(setMeeting)
+      .catch(() => setError('미팅 정보를 불러오지 못했습니다.'))
+      .finally(() => setLoading(false));
+  }, [meetingId]);
+
+  return { meeting, loading, error };
+}

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import PageLayout from "@/components/layout/PageLayout";
 import { useRecorder } from "@/features/meeting/useRecorder";
@@ -21,6 +21,12 @@ export default function MeetingDetailPage() {
   const [showStart, setShowStart] = useState(false);
   const [showEnd, setShowEnd] = useState(false);
   const [localStatus, setLocalStatus] = useState<LocalStatus>("pending");
+
+  useEffect(() => {
+    if (meeting?.status === "ANALYZING" || meeting?.status === "RECORDING") {
+      setLocalStatus(meeting.status.toLowerCase() as LocalStatus);
+    }
+  }, [meeting?.status]);
 
   const handleStartRecording = useCallback(async () => {
     await recorder.start();
@@ -91,6 +97,12 @@ export default function MeetingDetailPage() {
               >
                 1on1 미팅 시작하기
               </button>
+            </div>
+          )}
+          {localStatus === "recording" && (
+            <div className="border-t border-gray-200 px-8 py-6 flex flex-col items-center gap-2">
+              <span className="text-sm font-medium text-[#5F74FA]">🎙 녹음 중입니다</span>
+              <span className="text-xs text-gray-400">아래 플로팅 바에서 미팅을 종료할 수 있습니다.</span>
             </div>
           )}
         </div>

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -1,54 +1,58 @@
 import { useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import PageLayout from "@/components/layout/PageLayout";
-import { useMeetingStore } from "@/stores/meetingStore";
 import { useRecorder } from "@/features/meeting/useRecorder";
 import { useUploadRecording } from "@/features/meeting/useUploadRecording";
+import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
 import StartMeetingModal from "@/components/ui/StartMeetingModal";
 import EndMeetingModal from "@/components/ui/EndMeetingModal";
 import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
 import AnalysisLoading from "@/components/loading/AnalysisLoading";
+import type { MeetingDetail } from "@/types/meeting";
+
+type LocalStatus = "pending" | "recording" | "analyzing";
 
 export default function MeetingDetailPage() {
   const { meetingId } = useParams<{ meetingId: string }>();
   const navigate = useNavigate();
-  const { meetings, updateMeetingStatus, setRecordingDuration } = useMeetingStore();
-  const meeting = meetingId ? meetings.find((m) => m.id === meetingId) : null;
+  const { meeting, loading, error } = useMeetingDetail(meetingId);
   const recorder = useRecorder();
   const { upload } = useUploadRecording();
   const [showStart, setShowStart] = useState(false);
   const [showEnd, setShowEnd] = useState(false);
-
-  const isLeader = meeting?.myRole === "leader";
+  const [localStatus, setLocalStatus] = useState<LocalStatus>("pending");
 
   const handleStartRecording = useCallback(async () => {
     await recorder.start();
-    if (meeting) updateMeetingStatus(meeting.id, "recording");
-  }, [meeting, recorder, updateMeetingStatus]);
+    setLocalStatus("recording");
+  }, [recorder]);
 
   const handleEndMeeting = useCallback(() => {
-    if (!meeting) return;
-    setRecordingDuration(meeting.id, recorder.elapsed);
     recorder.stop();
-    updateMeetingStatus(meeting.id, "analyzing");
+    setLocalStatus("analyzing");
     setShowEnd(false);
-
-    // 녹음 Blob → BE 업로드
     setTimeout(() => {
       const blob = recorder.getBlob();
-      if (blob) upload(meeting.id, blob);
+      if (blob && meetingId) upload(meetingId, blob);
     }, 500);
-  }, [meeting, recorder, updateMeetingStatus, setRecordingDuration, upload]);
+  }, [recorder, meetingId, upload]);
 
-  const contentComponent = (() => {
-    // 1. 없는 미팅 ID로 접근했을 때
-    if (!meeting) {
-      return (
+  if (loading) {
+    return (
+      <PageLayout>
+        <div className="p-8 text-sm text-gray-400">불러오는 중...</div>
+      </PageLayout>
+    );
+  }
+
+  if (error || !meeting) {
+    return (
+      <PageLayout>
         <div className="p-8">
           <div className="flex flex-col gap-4 items-start">
             <h1 className="text-xl font-bold">1on1 미팅</h1>
             <p className="text-sm text-gray-500">
-              요청하신 미팅을 찾을 수 없습니다. 목록으로 돌아가서 다시 선택해주세요.
+              {error ?? "요청하신 미팅을 찾을 수 없습니다. 목록으로 돌아가서 다시 선택해주세요."}
             </p>
             <button
               onClick={() => navigate('/leader/meetings')}
@@ -58,57 +62,28 @@ export default function MeetingDetailPage() {
             </button>
           </div>
         </div>
-      );
-    }
+      </PageLayout>
+    );
+  }
 
-    // 2. 분석 중인 상태일 때
-    if (meeting.status === "analyzing") {
-      return (
+  if (localStatus === "analyzing") {
+    return (
+      <PageLayout>
         <div className="flex flex-col">
           <MeetingHeader meeting={meeting} />
-          <AnalysisLoading role={meeting.myRole} recordingDuration={meeting.recordingDuration} />
+          <AnalysisLoading role="leader" recordingDuration={recorder.elapsed} />
         </div>
-      );
-    }
+      </PageLayout>
+    );
+  }
 
-    // 3. 미팅 대기 중이거나 녹음 중일 때 (상세 화면)
-    return (
+  return (
+    <PageLayout>
       <div className="flex">
         <div className="flex-1 flex flex-col">
           <MeetingHeader meeting={meeting} />
 
-          <div className="flex-1 px-8 py-6 overflow-auto">
-            <section className="mb-8">
-              <h3 className="text-base font-bold flex items-center gap-2 mb-3">📋 미팅 프렙</h3>
-              <div className="bg-gray-50 rounded-xl p-6 text-center text-sm text-gray-400">
-                {isLeader ? "멤버의 미팅 프렙을 기다리고 있어요." : (
-                  <div>
-                    <p className="mb-3">아직 프렙을 공유하지 않았어요. 작성을 완료해주세요.</p>
-                    <button className="px-4 py-2 rounded-lg border border-[#5F74FA] text-[#5F74FA] text-sm hover:bg-[#5F74FA]/5">
-                      ✏️ 이어 작성하기
-                    </button>
-                  </div>
-                )}
-              </div>
-            </section>
-
-            <section className="mb-8">
-              <div className="flex items-center justify-between mb-3">
-                <h3 className="text-base font-bold flex items-center gap-2">💬 질문</h3>
-                {isLeader && (
-                  <div className="flex gap-2">
-                    <button className="px-3 py-1.5 rounded-lg border border-gray-200 text-xs hover:bg-gray-50">✨ AI 질문 생성</button>
-                    <button className="px-3 py-1.5 rounded-lg border border-gray-200 text-xs hover:bg-gray-50">📋 템플릿 불러오기</button>
-                  </div>
-                )}
-              </div>
-              <div className="border border-gray-200 rounded-xl p-4">
-                <input className="w-full text-sm text-gray-400 outline-none" placeholder="질문을 입력해주세요." readOnly />
-              </div>
-            </section>
-          </div>
-
-          {!recorder.isRecording && isLeader && meeting.status === "pending" && (
+          {!recorder.isRecording && localStatus === "pending" && (
             <div className="border-t border-gray-200 px-8 py-4 flex justify-center">
               <button
                 onClick={() => setShowStart(true)}
@@ -122,8 +97,11 @@ export default function MeetingDetailPage() {
 
         <div className="w-[280px] border-l border-gray-200 p-6 flex flex-col gap-6">
           <div>
-            <h4 className="font-semibold text-sm mb-2">나만의 노트 🔒</h4>
-            <textarea className="w-full h-32 border border-gray-200 rounded-lg p-3 text-sm resize-none focus:outline-none focus:border-[#4E62E6]" placeholder="나만 볼 수 있는 메모입니다." />
+            <h4 className="font-semibold text-sm mb-2">나만의 노트</h4>
+            <textarea
+              className="w-full h-32 border border-gray-200 rounded-lg p-3 text-sm resize-none focus:outline-none focus:border-[#4E62E6]"
+              placeholder="나만 볼 수 있는 메모입니다."
+            />
           </div>
         </div>
 
@@ -133,34 +111,34 @@ export default function MeetingDetailPage() {
           isRecording={recorder.isRecording}
           elapsed={recorder.elapsed}
           audioLevel={recorder.audioLevel}
-          isLeader={isLeader}
+          isLeader={true}
           onEndClick={() => setShowEnd(true)}
         />
       </div>
-    );
-  })();
-
-  return (
-    <PageLayout>
-      {contentComponent}
     </PageLayout>
   );
 }
 
-function MeetingHeader({ meeting }: { meeting: any }) {
-  const dateStr = new Date(meeting.date).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" });
-  const leaderName = meeting.myRole === "leader" ? "나" : meeting.partner.name;
-  const memberName = meeting.myRole === "member" ? "나" : meeting.partner.name;
+function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
+  const dateStr = new Date(meeting.scheduledAt).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 
   return (
     <div className="px-8 py-4 border-b border-gray-200">
       <h1 className="text-xl font-bold">{dateStr}</h1>
       <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
-        <span className="w-6 h-6 rounded-full bg-[#5F74FA] flex items-center justify-center text-white text-xs">{leaderName[0]}</span>
-        <span>{leaderName} (리더)</span>
+        <span className="w-6 h-6 rounded-full bg-[#5F74FA] flex items-center justify-center text-white text-xs">
+          {meeting.leaderName[0]}
+        </span>
+        <span>{meeting.leaderName} (리더)</span>
         <span className="text-gray-300">↔</span>
-        <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">{memberName[0]}</span>
-        <span>{memberName}</span>
+        <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">
+          {meeting.memberName[0]}
+        </span>
+        <span>{meeting.memberName}</span>
       </div>
     </div>
   );

--- a/src/pages/member/MeetingDetailPage.tsx
+++ b/src/pages/member/MeetingDetailPage.tsx
@@ -82,9 +82,7 @@ function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
         </span>
         <span>{meeting.leaderName} (리더)</span>
         <span className="text-gray-300">↔</span>
-        <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">
-          나
-        </span>
+        <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs" />
         <span>나</span>
       </div>
     </div>

--- a/src/pages/member/MeetingDetailPage.tsx
+++ b/src/pages/member/MeetingDetailPage.tsx
@@ -1,0 +1,92 @@
+import { useParams, useNavigate } from "react-router-dom";
+import PageLayout from "@/components/layout/PageLayout";
+import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
+import SurveyForm from "@/components/survey/SurveyForm";
+import AnalysisLoading from "@/components/loading/AnalysisLoading";
+import type { MeetingDetail } from "@/types/meeting";
+
+export default function MemberMeetingDetailPage() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+  const navigate = useNavigate();
+  const { meeting, loading, error } = useMeetingDetail(meetingId);
+
+  if (loading) {
+    return (
+      <PageLayout>
+        <div className="p-8 text-sm text-gray-400">불러오는 중...</div>
+      </PageLayout>
+    );
+  }
+
+  if (error || !meeting) {
+    return (
+      <PageLayout>
+        <div className="p-8">
+          <div className="flex flex-col gap-4 items-start">
+            <h1 className="text-xl font-bold">1on1 미팅</h1>
+            <p className="text-sm text-gray-500">
+              {error ?? "요청하신 미팅을 찾을 수 없습니다."}
+            </p>
+            <button
+              onClick={() => navigate('/member/dashboard')}
+              className="rounded-lg bg-[#5F74FA] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#4E62E6]"
+            >
+              대시보드로 이동
+            </button>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (meeting.status === "ANALYZING") {
+    return (
+      <PageLayout>
+        <div className="flex flex-col">
+          <MeetingHeader meeting={meeting} />
+          <AnalysisLoading role="member" />
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout>
+      <div className="flex flex-col">
+        <MeetingHeader meeting={meeting} />
+        <div className="bg-[#F7F8FA] px-5 py-8">
+          <SurveyForm
+            leaderName={meeting.leaderName}
+            scheduledAt={meeting.scheduledAt}
+            meetingId={meeting.meetingId}
+          />
+        </div>
+      </div>
+    </PageLayout>
+  );
+}
+
+function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
+  const dateStr = new Date(meeting.scheduledAt).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="px-8 py-4 border-b border-gray-200">
+      <h1 className="text-xl font-bold">{dateStr}</h1>
+      <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
+        <span className="w-6 h-6 rounded-full bg-[#5F74FA] flex items-center justify-center text-white text-xs">
+          {meeting.leaderName[0]}
+        </span>
+        <span>{meeting.leaderName} (리더)</span>
+        <span className="text-gray-300">↔</span>
+        <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">
+          나
+        </span>
+        <span>나</span>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/member/SurveyPage.tsx
+++ b/src/pages/member/SurveyPage.tsx
@@ -12,8 +12,8 @@ export default function SurveyPage() {
       <main className="min-h-[calc(100vh-3.5rem)] bg-[#F7F8FA] px-5 py-8 text-gray-900">
         <SurveyForm
           leaderName="이준혁"
-          scheduledAt={new Date().toISOString()}
-          meetingId={Number(meetingId ?? '0')}
+          scheduledAt="2026-04-29T09:00:00.000Z"
+          meetingId={meetingId ? (Number.isNaN(Number(meetingId)) ? 0 : Number(meetingId)) : 0}
         />
       </main>
     </PageLayout>

--- a/src/pages/member/SurveyPage.tsx
+++ b/src/pages/member/SurveyPage.tsx
@@ -1,164 +1,20 @@
-import { useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
-import Button from '@/components/ui/Button';
-import Card from '@/components/ui/Card';
-
-const mockSurvey = {
-  leaderName: '이준혁',
-  scheduledDate: '2026년 4월 29일 (화)',
-};
-
-const issueOptions = ['업무 블로커', '커리어 성장', '팀 협업', '리소스 요청', '기타'];
-const energyOptions = [
-  { value: 1, icon: '😫', label: '많이 지침' },
-  { value: 2, icon: '😳', label: '조금 힘듦' },
-  { value: 3, icon: '😊', label: '보통' },
-  { value: 4, icon: '😄', label: '좋음' },
-  { value: 5, icon: '🔥', label: '최고!' },
-];
-const desiredRoleOptions = ['그냥 들어주기', '방향성 코칭', '의사결정 도움', '리소스 확보'];
+import SurveyForm from '@/components/survey/SurveyForm';
 
 export default function SurveyPage() {
-  const [selectedIssues, setSelectedIssues] = useState<string[]>([]);
-  const [energyLevel, setEnergyLevel] = useState<number | null>(3);
-  const [desiredRoles, setDesiredRoles] = useState<string[]>([]);
-  const [message, setMessage] = useState('');
-
-  const canSubmit = selectedIssues.length > 0 && energyLevel !== null && desiredRoles.length > 0;
-
-  const selectedEnergyLabel = useMemo(
-    () => energyOptions.find((option) => option.value === energyLevel)?.label ?? '',
-    [energyLevel],
-  );
-
-  const toggleValue = (value: string, values: string[], setValues: (nextValues: string[]) => void) => {
-    setMessage('');
-    setValues(values.includes(value) ? values.filter((item) => item !== value) : [...values, value]);
-  };
-
-  const handleSubmit = () => {
-    if (!canSubmit) return;
-
-    const payload = {
-      meetingId: 10,
-      issues: selectedIssues,
-      energyLevel,
-      desiredRoles,
-    };
-
-    console.log('survey payload', payload);
-    setMessage('설문이 제출되었습니다.');
-  };
+  const { meetingId } = useParams<{ meetingId: string }>();
 
   return (
     <PageLayout>
       <Header title="1on1 사전 설문" />
       <main className="min-h-[calc(100vh-3.5rem)] bg-[#F7F8FA] px-5 py-8 text-gray-900">
-        <section className="mx-auto flex w-full max-w-[560px] flex-col items-center">
-          <p className="text-sm font-bold tracking-wide text-slate-400">{mockSurvey.leaderName}님과 1on1이 예정되어 있습니다.</p>
-          <h1 className="mt-5 text-center text-2xl font-bold leading-snug text-gray-900 ">
-            사전 설문 조사를 진행해 주세요!
-          </h1>
-          <p className="mt-4 text-center text-base tracking-wide text-slate-400">{mockSurvey.scheduledDate}</p>
-
-          <Card className="mt-10 w-full rounded-[20px] border-gray-200 px-9 py-9 shadow-sm">
-            <div className="space-y-9">
-              <section>
-                <h2 className="text-lg font-extrabold text-gray-900">Q1. 오늘 꼭 다루고 싶은 이슈는?</h2>
-                <div className="mt-5 flex flex-wrap gap-3">
-                  {issueOptions.map((issue) => {
-                    const isSelected = selectedIssues.includes(issue);
-                    return (
-                      <button
-                        key={issue}
-                        type="button"
-                        onClick={() => toggleValue(issue, selectedIssues, setSelectedIssues)}
-                        className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
-                          isSelected
-                            ? 'border-violet-500 bg-violet-50 text-violet-700'
-                            : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
-                        }`}
-                      >
-                        {issue}
-                      </button>
-                    );
-                  })}
-                </div>
-              </section>
-
-              <section>
-                <h2 className="text-lg font-extrabold text-gray-900">Q2. 지금 나의 에너지 레벨은?</h2>
-                <div className="mt-5 grid grid-cols-5 gap-2 sm:gap-3">
-                  {energyOptions.map((energy) => {
-                    const isSelected = energy.value === energyLevel;
-                    return (
-                      <button
-                        key={energy.value}
-                        type="button"
-                        onClick={() => {
-                          setEnergyLevel(energy.value);
-                          setMessage('');
-                        }}
-                        className={`flex aspect-square min-h-[88px] flex-col items-center justify-center rounded-[18px] border text-center transition-colors ${
-                          isSelected
-                            ? 'border-violet-500 bg-violet-50 text-violet-700 shadow-[0_0_0_1px_rgba(139,92,246,0.9)]'
-                            : 'border-slate-200 bg-white text-slate-400 hover:border-slate-300'
-                        }`}
-                      >
-                        <span className="text-3xl leading-none">{energy.icon}</span>
-                        <span className="mt-3 text-[11px] font-bold">{energy.label}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </section>
-
-              <section>
-                <h2 className="text-lg font-extrabold text-gray-900">Q3. 이번 미팅에서 리더에게 바라는 역할은?</h2>
-                <div className="mt-5 flex flex-wrap gap-3">
-                  {desiredRoleOptions.map((role) => {
-                    const isSelected = desiredRoles.includes(role);
-                    return (
-                      <button
-                        key={role}
-                        type="button"
-                        onClick={() => toggleValue(role, desiredRoles, setDesiredRoles)}
-                        className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
-                          isSelected
-                            ? 'border-violet-500 bg-violet-50 text-violet-700'
-                            : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
-                        }`}
-                      >
-                        {role}
-                      </button>
-                    );
-                  })}
-                </div>
-              </section>
-
-              <div className="pt-1">
-                <Button
-                  type="button"
-                  onClick={handleSubmit}
-                  disabled={!canSubmit}
-                  className={`h-14 w-full text-base ${
-                    canSubmit
-                      ? 'bg-gray-900 text-white hover:bg-gray-700'
-                      : 'bg-slate-100 text-slate-400 hover:bg-slate-100 disabled:opacity-100'
-                  }`}
-                >
-                  제출하기
-                </Button>
-                {message && <p className="mt-4 text-center text-sm font-medium text-green-600">{message}</p>}
-                <p className="mt-9 text-center text-sm text-slate-400">
-                  소요시간 약 30초 <span aria-hidden="true">⏱️</span>
-                </p>
-                <span className="sr-only">현재 에너지 레벨: {selectedEnergyLabel}</span>
-              </div>
-            </div>
-          </Card>
-        </section>
+        <SurveyForm
+          leaderName="이준혁"
+          scheduledAt={new Date().toISOString()}
+          meetingId={Number(meetingId ?? '0')}
+        />
       </main>
     </PageLayout>
   );

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -33,7 +33,7 @@ export interface MeetingDetail {
   round: number;
   scheduledAt: string;          // ISO 8601, 예: "2026-05-08T14:00:00"
   durationSec: number | null;
-  status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
+  status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED"; // 백엔드 API 응답값 (대문자)
   leaderName: string;
   memberName: string;
 }

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -27,3 +27,13 @@ export interface MeetingData {
 }
 
 export type AnalysisStep = 0 | 1 | 2 | 3;
+
+export interface MeetingDetail {
+  meetingId: number;
+  round: number;
+  scheduledAt: string;          // ISO 8601, 예: "2026-05-08T14:00:00"
+  durationSec: number | null;
+  status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
+  leaderName: string;
+  memberName: string;
+}


### PR DESCRIPTION
## 개요

기존 리더 전용이었던 MeetingDetailPage를 역할별로 분리하고,
`GET /api/v1/meetings/:meetingId` API에 연동했습니다.

## 변경 사항

### 신규 파일
- `src/api/meetings.ts` — fetchMeetingDetail API 함수
- `src/features/meeting/useMeetingDetail.ts` — 단건 조회 훅
- `src/components/survey/SurveyForm.tsx` — SurveyPage에서 폼 로직 추출
- `src/pages/member/MeetingDetailPage.tsx` — 멤버 전용 상세 페이지

### 수정 파일
- `src/types/meeting.ts` — MeetingDetail 타입 추가
- `src/pages/leader/MeetingDetailPage.tsx` — meetingStore 제거, API 연동
- `src/pages/member/SurveyPage.tsx` — SurveyForm 래퍼로 전환
- `src/app/router.tsx` — 라우트 분리 (/leader/meeting/:id, /member/meeting/:id)

## 화면 동작

**리더** `/leader/meeting/:meetingId`
- PENDING: 미팅 시작 버튼 → 녹음 플로우
- RECORDING: 녹음 중 UI + 플로팅 바
- ANALYZING: AnalysisLoading 화면

**멤버** `/member/meeting/:meetingId`
- PENDING: SurveyForm 임베드 (사전 설문 제출)
- ANALYZING: AnalysisLoading 화면

## 스코프 외 (추후 처리)
- COMPLETED 상태의 멤버 피드백 화면 (MeetingFeedbackPage)
- analyzing → completed 전환 폴링 (useMeetingStatus)
- SurveyPage 자체 API 연동 (현재 leaderName 하드코딩)
