### PR TITLE
#DESIGN: update feedback card semantic status styles

### DIFF
--- a/src/components/feedback/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard.tsx
@@ -1,19 +1,35 @@
 export interface FeedbackCardProps {
   title: string;
   content: string;
-  type?: 'positive' | 'negative' | 'neutral';
+  type?: 'error' | 'warning' | 'info' | 'success';
 }
 
-export function FeedbackCard({ title, content, type = 'neutral' }: FeedbackCardProps) {
-  const colors = {
-    positive: 'border-green-200 bg-green-50',
-    negative: 'border-red-200 bg-red-50',
-    neutral: 'border-gray-200 bg-gray-50',
-  };
+export const feedbackCardStyles = {
+  error: {
+    card: 'border-red-200 bg-red-50',
+    title: 'text-red-700',
+  },
+  warning: {
+    card: 'border-yellow-200 bg-yellow-50',
+    title: 'text-yellow-700',
+  },
+  info: {
+    card: 'border-blue-200 bg-blue-50',
+    title: 'text-blue-700',
+  },
+  success: {
+    card: 'border-green-200 bg-green-50',
+    title: 'text-green-700',
+  },
+} as const;
+
+export function FeedbackCard({ title, content, type = 'info' }: FeedbackCardProps) {
+  const styles = feedbackCardStyles[type];
+
   return (
-    <div className={`rounded-lg border p-4 ${colors[type]}`}>
-      <h4 className="text-sm font-medium text-gray-800 mb-1">{title}</h4>
-      <p className="text-sm text-gray-600">{content}</p>
+    <div className={`rounded-xl border p-4 ${styles.card}`}>
+      <h4 className={`mb-1 text-sm font-medium ${styles.title}`}>{title}</h4>
+      <p className="whitespace-pre-line text-sm text-gray-600">{content}</p>
     </div>
   );
 }


### PR DESCRIPTION
### **개요**
FeedbackCard 컴포넌트 디자인 수정: 기존의 positive, negative, neutral 표현에서 error, warning, info, success 상태로 변경 


 ###  **변경 사항**
  - FeedbackCardProps.type 값을 error | warning | info | success로 변경
  - 각 타입별 카드 색상 적용
      - error: red
      - warning: yellow
      - info: blue
      - success: green   
  - 기본 타입을 info로 설정
  - 카드 모서리를 rounded-xl로 변경
  - 카드 제목 색상을 카드 타입에 맞는 색상으로 변경
      - error: text-red-700
      - warning: text-yellow-700
      - info: text-blue-700
      - success: text-green-700