### PR TITLE
feat: 인증 백엔드 연동 및 사용자 정보 실시간 반영

### DIFF
--- a/docs/superpowers/plans/2026-05-18-meeting-detail-role-split.md
+++ b/docs/superpowers/plans/2026-05-18-meeting-detail-role-split.md
@@ -1,0 +1,743 @@
+# 미팅 상세 페이지 역할 분리 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 리더/멤버 전용 미팅 상세 페이지를 분리하고, 백엔드 단건 조회 API를 연동한다.
+
+**Architecture:** `useMeetingDetail` 훅이 `GET /api/v1/meetings/:meetingId`를 호출해 두 페이지에 공유된다. 리더 페이지는 기존 녹음 플로우를 로컬 상태로 관리하고, 멤버 페이지는 `SurveyForm` 컴포넌트를 임베드한다. `SurveyPage`는 `SurveyForm`의 래퍼로만 남아 기존 라우트를 유지한다.
+
+**Tech Stack:** React, TypeScript, Axios (`api/client.ts`), Zustand, React Router v6, Tailwind CSS
+
+> **참고:** 이 프로젝트에는 테스트 프레임워크가 설정되어 있지 않아 TDD 단계는 생략한다. 각 태스크 완료 후 `npm run dev` 서버에서 브라우저로 직접 확인한다. 타입 오류는 `npm run type-check`로 검증한다.
+
+---
+
+## 파일 맵
+
+| 작업 | 파일 | 설명 |
+|------|------|------|
+| 생성 | `src/api/meetings.ts` | `fetchMeetingDetail` API 함수 |
+| 생성 | `src/features/meeting/useMeetingDetail.ts` | 단건 조회 훅 |
+| 생성 | `src/components/survey/SurveyForm.tsx` | 설문 폼 컴포넌트 (SurveyPage에서 추출) |
+| 수정 | `src/pages/member/SurveyPage.tsx` | SurveyForm 래퍼로 교체 |
+| 수정 | `src/types/meeting.ts` | `MeetingDetail` 타입 추가 |
+| 수정 | `src/pages/leader/MeetingDetailPage.tsx` | useMeetingDetail 연동, 로컬 상태로 리팩토링 |
+| 생성 | `src/pages/member/MeetingDetailPage.tsx` | SurveyForm 임베드 멤버 페이지 |
+| 수정 | `src/app/router.tsx` | 멤버 라우트 교체 |
+
+---
+
+## Task 1: MeetingDetail 타입 추가
+
+**Files:**
+- Modify: `src/types/meeting.ts`
+
+- [ ] **Step 1: `MeetingDetail` 인터페이스 추가**
+
+`src/types/meeting.ts` 파일 끝에 다음을 추가한다:
+
+```typescript
+export interface MeetingDetail {
+  meetingId: number;
+  round: number;
+  scheduledAt: string;          // ISO 8601, 예: "2026-05-08T14:00:00"
+  durationSec: number | null;
+  status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
+  leaderName: string;
+  memberName: string;
+}
+```
+
+- [ ] **Step 2: 타입 검사**
+
+```bash
+npm run type-check
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/types/meeting.ts
+git commit -m "feat: add MeetingDetail API response type"
+```
+
+---
+
+## Task 2: API 함수 생성
+
+**Files:**
+- Create: `src/api/meetings.ts`
+
+- [ ] **Step 1: `src/api/meetings.ts` 생성**
+
+```typescript
+import apiClient from './client';
+import type { ApiResponse } from './types';
+import type { MeetingDetail } from '@/types/meeting';
+
+export async function fetchMeetingDetail(meetingId: string): Promise<MeetingDetail> {
+  const res = await apiClient.get<ApiResponse<MeetingDetail>>(`/api/v1/meetings/${meetingId}`);
+  return res.data.data;
+}
+```
+
+- [ ] **Step 2: 타입 검사**
+
+```bash
+npm run type-check
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/api/meetings.ts
+git commit -m "feat: add fetchMeetingDetail API function"
+```
+
+---
+
+## Task 3: useMeetingDetail 훅 생성
+
+**Files:**
+- Create: `src/features/meeting/useMeetingDetail.ts`
+
+- [ ] **Step 1: `src/features/meeting/useMeetingDetail.ts` 생성**
+
+```typescript
+import { useState, useEffect } from 'react';
+import { fetchMeetingDetail } from '@/api/meetings';
+import type { MeetingDetail } from '@/types/meeting';
+
+export function useMeetingDetail(meetingId: string | undefined) {
+  const [meeting, setMeeting] = useState<MeetingDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!meetingId) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    fetchMeetingDetail(meetingId)
+      .then(setMeeting)
+      .catch(() => setError('미팅 정보를 불러오지 못했습니다.'))
+      .finally(() => setLoading(false));
+  }, [meetingId]);
+
+  return { meeting, loading, error };
+}
+```
+
+- [ ] **Step 2: 타입 검사**
+
+```bash
+npm run type-check
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/features/meeting/useMeetingDetail.ts
+git commit -m "feat: add useMeetingDetail hook"
+```
+
+---
+
+## Task 4: SurveyForm 컴포넌트 추출
+
+**Files:**
+- Create: `src/components/survey/SurveyForm.tsx`
+- Modify: `src/pages/member/SurveyPage.tsx`
+
+- [ ] **Step 1: `src/components/survey/SurveyForm.tsx` 생성**
+
+기존 `SurveyPage`의 상태 로직과 Q1/Q2/Q3 폼을 이 컴포넌트로 이동한다. `PageLayout`과 `Header`는 포함하지 않는다.
+
+```typescript
+import { useMemo, useState } from 'react';
+import Button from '@/components/ui/Button';
+import Card from '@/components/ui/Card';
+
+const issueOptions = ['업무 블로커', '커리어 성장', '팀 협업', '리소스 요청', '기타'];
+const energyOptions = [
+  { value: 1, icon: '😫', label: '많이 지침' },
+  { value: 2, icon: '😳', label: '조금 힘듦' },
+  { value: 3, icon: '😊', label: '보통' },
+  { value: 4, icon: '😄', label: '좋음' },
+  { value: 5, icon: '🔥', label: '최고!' },
+];
+const desiredRoleOptions = ['그냥 들어주기', '방향성 코칭', '의사결정 도움', '리소스 확보'];
+
+interface SurveyFormProps {
+  leaderName: string;
+  scheduledAt: string;
+  meetingId: number;
+}
+
+export default function SurveyForm({ leaderName, scheduledAt, meetingId }: SurveyFormProps) {
+  const [selectedIssues, setSelectedIssues] = useState<string[]>([]);
+  const [energyLevel, setEnergyLevel] = useState<number | null>(3);
+  const [desiredRoles, setDesiredRoles] = useState<string[]>([]);
+  const [message, setMessage] = useState('');
+
+  const canSubmit = selectedIssues.length > 0 && energyLevel !== null && desiredRoles.length > 0;
+
+  const selectedEnergyLabel = useMemo(
+    () => energyOptions.find((option) => option.value === energyLevel)?.label ?? '',
+    [energyLevel],
+  );
+
+  const scheduledDate = useMemo(
+    () =>
+      new Date(scheduledAt).toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'short',
+      }),
+    [scheduledAt],
+  );
+
+  const toggleValue = (value: string, values: string[], setValues: (next: string[]) => void) => {
+    setMessage('');
+    setValues(values.includes(value) ? values.filter((item) => item !== value) : [...values, value]);
+  };
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    const payload = { meetingId, issues: selectedIssues, energyLevel, desiredRoles };
+    console.log('survey payload', payload);
+    setMessage('설문이 제출되었습니다.');
+  };
+
+  return (
+    <section className="mx-auto flex w-full max-w-[560px] flex-col items-center">
+      <p className="text-sm font-bold tracking-wide text-slate-400">
+        {leaderName}님과 1on1이 예정되어 있습니다.
+      </p>
+      <h1 className="mt-5 text-center text-2xl font-bold leading-snug text-gray-900">
+        사전 설문 조사를 진행해 주세요!
+      </h1>
+      <p className="mt-4 text-center text-base tracking-wide text-slate-400">{scheduledDate}</p>
+
+      <Card className="mt-10 w-full rounded-[20px] border-gray-200 px-9 py-9 shadow-sm">
+        <div className="space-y-9">
+          <section>
+            <h2 className="text-lg font-extrabold text-gray-900">Q1. 오늘 꼭 다루고 싶은 이슈는?</h2>
+            <div className="mt-5 flex flex-wrap gap-3">
+              {issueOptions.map((issue) => {
+                const isSelected = selectedIssues.includes(issue);
+                return (
+                  <button
+                    key={issue}
+                    type="button"
+                    onClick={() => toggleValue(issue, selectedIssues, setSelectedIssues)}
+                    className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
+                      isSelected
+                        ? 'border-violet-500 bg-violet-50 text-violet-700'
+                        : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                    }`}
+                  >
+                    {issue}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-extrabold text-gray-900">Q2. 지금 나의 에너지 레벨은?</h2>
+            <div className="mt-5 grid grid-cols-5 gap-2 sm:gap-3">
+              {energyOptions.map((energy) => {
+                const isSelected = energy.value === energyLevel;
+                return (
+                  <button
+                    key={energy.value}
+                    type="button"
+                    onClick={() => { setEnergyLevel(energy.value); setMessage(''); }}
+                    className={`flex aspect-square min-h-[88px] flex-col items-center justify-center rounded-[18px] border text-center transition-colors ${
+                      isSelected
+                        ? 'border-violet-500 bg-violet-50 text-violet-700 shadow-[0_0_0_1px_rgba(139,92,246,0.9)]'
+                        : 'border-slate-200 bg-white text-slate-400 hover:border-slate-300'
+                    }`}
+                  >
+                    <span className="text-3xl leading-none">{energy.icon}</span>
+                    <span className="mt-3 text-[11px] font-bold">{energy.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-extrabold text-gray-900">Q3. 이번 미팅에서 리더에게 바라는 역할은?</h2>
+            <div className="mt-5 flex flex-wrap gap-3">
+              {desiredRoleOptions.map((role) => {
+                const isSelected = desiredRoles.includes(role);
+                return (
+                  <button
+                    key={role}
+                    type="button"
+                    onClick={() => toggleValue(role, desiredRoles, setDesiredRoles)}
+                    className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
+                      isSelected
+                        ? 'border-violet-500 bg-violet-50 text-violet-700'
+                        : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                    }`}
+                  >
+                    {role}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <div className="pt-1">
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className={`h-14 w-full text-base ${
+                canSubmit
+                  ? 'bg-gray-900 text-white hover:bg-gray-700'
+                  : 'bg-slate-100 text-slate-400 hover:bg-slate-100 disabled:opacity-100'
+              }`}
+            >
+              제출하기
+            </Button>
+            {message && <p className="mt-4 text-center text-sm font-medium text-green-600">{message}</p>}
+            <p className="mt-9 text-center text-sm text-slate-400">
+              소요시간 약 30초 <span aria-hidden="true">⏱️</span>
+            </p>
+            <span className="sr-only">현재 에너지 레벨: {selectedEnergyLabel}</span>
+          </div>
+        </div>
+      </Card>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: `src/pages/member/SurveyPage.tsx`를 SurveyForm 래퍼로 교체**
+
+```typescript
+import { useParams } from 'react-router-dom';
+import Header from '@/components/layout/Header';
+import PageLayout from '@/components/layout/PageLayout';
+import SurveyForm from '@/components/survey/SurveyForm';
+
+export default function SurveyPage() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+
+  return (
+    <PageLayout>
+      <Header title="1on1 사전 설문" />
+      <main className="min-h-[calc(100vh-3.5rem)] bg-[#F7F8FA] px-5 py-8 text-gray-900">
+        <SurveyForm
+          leaderName="이준혁"
+          scheduledAt={new Date().toISOString()}
+          meetingId={Number(meetingId ?? '0')}
+        />
+      </main>
+    </PageLayout>
+  );
+}
+```
+
+> **참고:** `leaderName`과 `scheduledAt`은 SurveyPage가 자체 API를 연동하기 전까지 임시값을 사용한다. 멤버 MeetingDetailPage에서는 실제 API 데이터를 넘긴다.
+
+- [ ] **Step 3: 타입 검사**
+
+```bash
+npm run type-check
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 4: 브라우저 확인**
+
+`npm run dev` 후 `http://localhost:5173/member/survey/1` 접속.  
+기존 설문 화면과 동일하게 보이면 정상.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/survey/SurveyForm.tsx src/pages/member/SurveyPage.tsx
+git commit -m "feat: extract SurveyForm component from SurveyPage"
+```
+
+---
+
+## Task 5: 리더 MeetingDetailPage 리팩토링
+
+**Files:**
+- Modify: `src/pages/leader/MeetingDetailPage.tsx`
+
+기존 `useMeetingStore` 의존성을 제거하고 `useMeetingDetail` 훅과 로컬 상태로 교체한다.
+
+- [ ] **Step 1: `src/pages/leader/MeetingDetailPage.tsx` 전체 교체**
+
+```typescript
+import { useState, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import PageLayout from "@/components/layout/PageLayout";
+import { useRecorder } from "@/features/meeting/useRecorder";
+import { useUploadRecording } from "@/features/meeting/useUploadRecording";
+import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
+import StartMeetingModal from "@/components/ui/StartMeetingModal";
+import EndMeetingModal from "@/components/ui/EndMeetingModal";
+import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
+import AnalysisLoading from "@/components/loading/AnalysisLoading";
+import type { MeetingDetail } from "@/types/meeting";
+
+type LocalStatus = "pending" | "recording" | "analyzing";
+
+export default function MeetingDetailPage() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+  const navigate = useNavigate();
+  const { meeting, loading, error } = useMeetingDetail(meetingId);
+  const recorder = useRecorder();
+  const { upload } = useUploadRecording();
+  const [showStart, setShowStart] = useState(false);
+  const [showEnd, setShowEnd] = useState(false);
+  const [localStatus, setLocalStatus] = useState<LocalStatus>("pending");
+
+  const handleStartRecording = useCallback(async () => {
+    await recorder.start();
+    setLocalStatus("recording");
+  }, [recorder]);
+
+  const handleEndMeeting = useCallback(() => {
+    recorder.stop();
+    setLocalStatus("analyzing");
+    setShowEnd(false);
+    setTimeout(() => {
+      const blob = recorder.getBlob();
+      if (blob && meetingId) upload(meetingId, blob);
+    }, 500);
+  }, [recorder, meetingId, upload]);
+
+  if (loading) {
+    return (
+      <PageLayout>
+        <div className="p-8 text-sm text-gray-400">불러오는 중...</div>
+      </PageLayout>
+    );
+  }
+
+  if (error || !meeting) {
+    return (
+      <PageLayout>
+        <div className="p-8">
+          <div className="flex flex-col gap-4 items-start">
+            <h1 className="text-xl font-bold">1on1 미팅</h1>
+            <p className="text-sm text-gray-500">
+              {error ?? "요청하신 미팅을 찾을 수 없습니다. 목록으로 돌아가서 다시 선택해주세요."}
+            </p>
+            <button
+              onClick={() => navigate('/leader/meetings')}
+              className="rounded-lg bg-[#5F74FA] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#4E62E6]"
+            >
+              1on1 목록으로 이동
+            </button>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (localStatus === "analyzing") {
+    return (
+      <PageLayout>
+        <div className="flex flex-col">
+          <MeetingHeader meeting={meeting} />
+          <AnalysisLoading role="leader" recordingDuration={recorder.elapsed} />
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout>
+      <div className="flex">
+        <div className="flex-1 flex flex-col">
+          <MeetingHeader meeting={meeting} />
+
+          {!recorder.isRecording && localStatus === "pending" && (
+            <div className="border-t border-gray-200 px-8 py-4 flex justify-center">
+              <button
+                onClick={() => setShowStart(true)}
+                className="px-8 py-3 rounded-full text-white font-medium bg-[#5F74FA] hover:bg-[#4E62E6] shadow-lg shadow-[#5F74FA]/30 transition-all"
+              >
+                1on1 미팅 시작하기
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="w-[280px] border-l border-gray-200 p-6 flex flex-col gap-6">
+          <div>
+            <h4 className="font-semibold text-sm mb-2">나만의 노트</h4>
+            <textarea
+              className="w-full h-32 border border-gray-200 rounded-lg p-3 text-sm resize-none focus:outline-none focus:border-[#4E62E6]"
+              placeholder="나만 볼 수 있는 메모입니다."
+            />
+          </div>
+        </div>
+
+        <StartMeetingModal isOpen={showStart} onClose={() => setShowStart(false)} onStart={handleStartRecording} />
+        <EndMeetingModal isOpen={showEnd} onClose={() => setShowEnd(false)} onEnd={handleEndMeeting} />
+        <RecordingFloatingBar
+          isRecording={recorder.isRecording}
+          elapsed={recorder.elapsed}
+          audioLevel={recorder.audioLevel}
+          isLeader={true}
+          onEndClick={() => setShowEnd(true)}
+        />
+      </div>
+    </PageLayout>
+  );
+}
+
+function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
+  const dateStr = new Date(meeting.scheduledAt).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="px-8 py-4 border-b border-gray-200">
+      <h1 className="text-xl font-bold">{dateStr}</h1>
+      <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
+        <span className="w-6 h-6 rounded-full bg-[#5F74FA] flex items-center justify-center text-white text-xs">
+          {meeting.leaderName[0]}
+        </span>
+        <span>{meeting.leaderName} (리더)</span>
+        <span className="text-gray-300">↔</span>
+        <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">
+          {meeting.memberName[0]}
+        </span>
+        <span>{meeting.memberName}</span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 타입 검사**
+
+```bash
+npm run type-check
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 3: 브라우저 확인**
+
+`http://localhost:5173/leader/meeting/10` 접속 (백엔드 실행 중이어야 함).  
+- 로딩 스피너 → 미팅 정보 표시 순서 확인  
+- "1on1 미팅 시작하기" 버튼 표시 확인  
+- 없는 ID(`/leader/meeting/9999`)로 접속 시 에러 메시지 + 목록 버튼 확인
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/pages/leader/MeetingDetailPage.tsx
+git commit -m "feat: refactor leader MeetingDetailPage to use API"
+```
+
+---
+
+## Task 6: 멤버 MeetingDetailPage 생성
+
+**Files:**
+- Create: `src/pages/member/MeetingDetailPage.tsx`
+
+- [ ] **Step 1: `src/pages/member/MeetingDetailPage.tsx` 생성**
+
+```typescript
+import { useParams, useNavigate } from "react-router-dom";
+import PageLayout from "@/components/layout/PageLayout";
+import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
+import SurveyForm from "@/components/survey/SurveyForm";
+import AnalysisLoading from "@/components/loading/AnalysisLoading";
+import type { MeetingDetail } from "@/types/meeting";
+
+export default function MemberMeetingDetailPage() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+  const navigate = useNavigate();
+  const { meeting, loading, error } = useMeetingDetail(meetingId);
+
+  if (loading) {
+    return (
+      <PageLayout>
+        <div className="p-8 text-sm text-gray-400">불러오는 중...</div>
+      </PageLayout>
+    );
+  }
+
+  if (error || !meeting) {
+    return (
+      <PageLayout>
+        <div className="p-8">
+          <div className="flex flex-col gap-4 items-start">
+            <h1 className="text-xl font-bold">1on1 미팅</h1>
+            <p className="text-sm text-gray-500">
+              {error ?? "요청하신 미팅을 찾을 수 없습니다."}
+            </p>
+            <button
+              onClick={() => navigate('/member/dashboard')}
+              className="rounded-lg bg-[#5F74FA] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#4E62E6]"
+            >
+              대시보드로 이동
+            </button>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (meeting.status === "ANALYZING") {
+    return (
+      <PageLayout>
+        <div className="flex flex-col">
+          <MeetingHeader meeting={meeting} />
+          <AnalysisLoading role="member" />
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout>
+      <div className="flex flex-col">
+        <MeetingHeader meeting={meeting} />
+        <div className="bg-[#F7F8FA] px-5 py-8">
+          <SurveyForm
+            leaderName={meeting.leaderName}
+            scheduledAt={meeting.scheduledAt}
+            meetingId={meeting.meetingId}
+          />
+        </div>
+      </div>
+    </PageLayout>
+  );
+}
+
+function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
+  const dateStr = new Date(meeting.scheduledAt).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="px-8 py-4 border-b border-gray-200">
+      <h1 className="text-xl font-bold">{dateStr}</h1>
+      <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
+        <span className="w-6 h-6 rounded-full bg-[#5F74FA] flex items-center justify-center text-white text-xs">
+          {meeting.leaderName[0]}
+        </span>
+        <span>{meeting.leaderName} (리더)</span>
+        <span className="text-gray-300">↔</span>
+        <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">
+          나
+        </span>
+        <span>나</span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 타입 검사**
+
+```bash
+npm run type-check
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/pages/member/MeetingDetailPage.tsx
+git commit -m "feat: add member MeetingDetailPage with embedded SurveyForm"
+```
+
+---
+
+## Task 7: 라우터 업데이트
+
+**Files:**
+- Modify: `src/app/router.tsx`
+
+- [ ] **Step 1: 라우터에서 멤버 미팅 라우트 교체**
+
+`src/app/router.tsx`의 import 블록과 라우트 배열을 수정한다:
+
+```typescript
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import LoginPage from '@/pages/auth/LoginPage';
+import SignupPage from '@/pages/auth/SignupPage';
+import LeaderDashboard from '@/pages/leader/LeaderDashboard';
+import MeetingsPage from '@/pages/leader/MeetingsPage';
+import LeaderMeetingDetailPage from '@/pages/leader/MeetingDetailPage';
+import PromiseLedgerPage from '@/pages/leader/PromiseLedgerPage';
+import MemberDashboard from '@/pages/member/MemberDashboard';
+import MemberMeetingDetailPage from '@/pages/member/MeetingDetailPage';
+import SurveyPage from '@/pages/member/SurveyPage';
+
+const router = createBrowserRouter([
+  { path: '/', element: <Navigate to="/leader/dashboard" replace /> },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/signup', element: <SignupPage /> },
+  { path: '/leader/dashboard', element: <LeaderDashboard /> },
+  { path: '/leader/meetings', element: <MeetingsPage /> },
+  { path: '/leader/meeting/:meetingId', element: <LeaderMeetingDetailPage /> },
+  { path: '/leader/promises', element: <PromiseLedgerPage /> },
+  { path: '/leader/reports', element: <LeaderDashboard /> },
+  { path: '/leader/9box', element: <LeaderDashboard /> },
+  { path: '/leader/overview', element: <LeaderDashboard /> },
+  { path: '/member/dashboard', element: <MemberDashboard /> },
+  { path: '/member/meeting/:meetingId', element: <MemberMeetingDetailPage /> },
+  { path: '/member/survey/:meetingId', element: <SurveyPage /> },
+  { path: '/settings', element: <LeaderDashboard /> },
+  { path: '/invite', element: <LeaderDashboard /> },
+]);
+
+export default router;
+```
+
+> `MeetingFeedbackPage` import와 `/meeting` (무 :id) 라우트는 제거한다.
+
+- [ ] **Step 2: 타입 검사 및 린트**
+
+```bash
+npm run type-check && npm run lint
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 3: 브라우저 최종 확인**
+
+`npm run dev` 후:
+1. `http://localhost:5173/leader/meeting/10` → 리더 화면 (시작 버튼 표시)
+2. `http://localhost:5173/member/meeting/11` → 멤버 화면 (설문 폼 표시)
+3. `http://localhost:5173/member/survey/11` → 기존 전체 설문 페이지 정상 표시
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/app/router.tsx
+git commit -m "feat: wire leader/member MeetingDetailPage routes"
+```

--- a/docs/superpowers/specs/2026-05-18-meeting-detail-role-split-design.md
+++ b/docs/superpowers/specs/2026-05-18-meeting-detail-role-split-design.md
@@ -1,0 +1,155 @@
+# 미팅 상세 페이지 역할 분리 설계
+
+**날짜:** 2026-05-18  
+**브랜치:** jisu-meeting
+
+---
+
+## 배경
+
+기존 `MeetingDetailPage`는 리더 전용으로만 작성되어 있고, 멤버가 접근하는 미팅 상세 화면이 없었다. 또한 미팅 데이터를 인메모리 store에서 읽고 있어 실제 백엔드 데이터와 연동이 안 되어 있었다.
+
+---
+
+## 목표
+
+- 리더와 멤버 각각 전용 미팅 상세 페이지를 분리 구현
+- 리더: 기존 미팅 시작/녹음 플로우 유지
+- 멤버: SurveyPage 폼 콘텐츠를 `<div>`로 임베드한 화면 제공
+- 백엔드 단건 조회 API 연동
+
+---
+
+## 합의된 백엔드 API
+
+### 미팅 단건 조회
+
+```
+GET /api/v1/meetings/:meetingId
+Authorization: Bearer <token>
+```
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "code": "SUCCESS",
+  "message": "요청이 성공적으로 처리되었습니다.",
+  "data": {
+    "meetingId": 10,
+    "round": 12,
+    "scheduledAt": "2026-05-08T14:00:00",
+    "durationSec": 2400,
+    "status": "COMPLETED",
+    "leaderName": "이준혁",
+    "memberName": "강다은"
+  }
+}
+```
+
+**보안:** 서버는 토큰 기반으로 요청자가 해당 미팅의 리더 또는 멤버인지 검증. 관계없는 사용자는 403 반환. 응답 데이터는 두 역할 모두 동일.
+
+---
+
+## 파일 구조
+
+```
+src/
+├── api/
+│   └── meetings.ts                       (신규) API 함수
+├── features/meeting/
+│   └── useMeetingDetail.ts               (신규) 단건 조회 훅
+├── components/survey/
+│   └── SurveyForm.tsx                    (신규) SurveyPage에서 폼 추출
+├── pages/
+│   ├── leader/
+│   │   └── MeetingDetailPage.tsx         (리팩토링) API 연동
+│   └── member/
+│       └── MeetingDetailPage.tsx         (신규) SurveyForm 임베드
+└── types/
+    └── meeting.ts                        (수정) MeetingDetail 타입 추가
+```
+
+---
+
+## 라우팅
+
+```
+/leader/meeting/:meetingId  →  pages/leader/MeetingDetailPage
+/member/meeting/:meetingId  →  pages/member/MeetingDetailPage   ← 변경 (기존: MeetingFeedbackPage)
+/member/survey/:meetingId   →  pages/member/SurveyPage          ← 유지 (SurveyForm 래퍼)
+```
+
+**MeetingFeedbackPage 처리:**  
+기존 `MeetingFeedbackPage`는 파일은 유지하되 라우터에서 제거한다.  
+완료된 미팅(COMPLETED)의 피드백 화면은 추후 별도 스펙으로 처리한다.  
+이번 스코프에서 `MemberMeetingDetailPage`는 PENDING / ANALYZING 상태만 처리한다.
+
+---
+
+## 데이터 흐름
+
+### `useMeetingDetail(meetingId: string)`
+
+```
+1. GET /api/v1/meetings/:meetingId 호출
+2. loading / error / meeting 반환
+3. meeting 타입: MeetingDetail (아래 타입 섹션 참조)
+```
+
+두 페이지(리더/멤버) 모두 이 훅 하나를 사용.
+
+---
+
+## 타입
+
+`src/types/meeting.ts`에 추가:
+
+```ts
+export interface MeetingDetail {
+  meetingId: number;
+  round: number;
+  scheduledAt: string;
+  durationSec: number | null;
+  status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
+  leaderName: string;
+  memberName: string;
+}
+```
+
+---
+
+## 각 페이지 화면 구성
+
+### 리더 MeetingDetailPage
+
+- 미팅 헤더: 날짜, `leaderName(나) ↔ memberName` 표시
+- `status === "PENDING"` → "1on1 미팅 시작하기" 버튼
+- 녹음 플로우 유지: StartMeetingModal, RecordingFloatingBar, EndMeetingModal
+- 오른쪽 사이드바 "나만의 노트" 유지
+- `status === "ANALYZING"` → AnalysisLoading
+
+### 멤버 MeetingDetailPage
+
+- 미팅 헤더: 날짜, `leaderName ↔ 나` 표시
+- `<div>` 안에 `<SurveyForm leaderName={meeting.leaderName} scheduledAt={meeting.scheduledAt} />` 임베드
+- 녹음/시작 버튼 없음
+
+### SurveyForm 컴포넌트
+
+- 기존 `SurveyPage`의 Q1/Q2/Q3 + 제출 버튼 로직 추출
+- Props: `leaderName: string`, `scheduledAt: string`
+- `SurveyPage`는 `<SurveyForm>`을 감싸는 래퍼로만 남음 (기존 라우트 유지)
+
+---
+
+## 오너십 (CLAUDE.md 기준)
+
+| 파일 | 팀 |
+|------|-----|
+| `pages/leader/MeetingDetailPage.tsx` | FE1 |
+| `pages/member/MeetingDetailPage.tsx` | FE1 |
+| `api/meetings.ts` | FE1 |
+| `features/meeting/useMeetingDetail.ts` | FE1 |
+| `components/survey/SurveyForm.tsx` | FE2 |
+| `types/meeting.ts` | 공통 (추가만) |

--- a/src/api/analysis.ts
+++ b/src/api/analysis.ts
@@ -1,0 +1,11 @@
+import apiClient from './client';
+import type { AnalysisStatusData } from '@/types/analysis';
+
+interface AnalysisStatusResponse {
+  data: AnalysisStatusData;
+}
+
+export async function fetchAnalysisStatus(meetingId: string): Promise<AnalysisStatusData> {
+  const { data } = await apiClient.get<AnalysisStatusResponse>(`/api/v1/analysis/${meetingId}/status`);
+  return data.data;
+}

--- a/src/api/analysis.ts
+++ b/src/api/analysis.ts
@@ -6,6 +6,6 @@ interface AnalysisStatusResponse {
 }
 
 export async function fetchAnalysisStatus(meetingId: string): Promise<AnalysisStatusData> {
-  const { data } = await apiClient.get<AnalysisStatusResponse>(`/api/v1/analysis/${meetingId}/status`);
+  const { data } = await apiClient.get<AnalysisStatusResponse>(`/v1/analysis/${meetingId}/status`);
   return data.data;
 }

--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -6,3 +6,12 @@ export async function fetchMeetingDetail(meetingId: string): Promise<MeetingDeta
   const res = await apiClient.get<ApiResponse<MeetingDetail>>(`/api/v1/meetings/${meetingId}`);
   return res.data.data;
 }
+
+export async function uploadRecording(meetingId: string, blob: Blob, durationSec: number): Promise<void> {
+  const formData = new FormData();
+  formData.append('file', blob, 'recording.webm');
+  formData.append('durationSec', String(durationSec));
+  await apiClient.post(`/api/v1/meetings/${meetingId}/recording`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+}

--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -3,7 +3,7 @@ import type { ApiResponse } from './types';
 import type { MeetingDetail } from '@/types/meeting';
 
 export async function fetchMeetingDetail(meetingId: string): Promise<MeetingDetail> {
-  const res = await apiClient.get<ApiResponse<MeetingDetail>>(`/api/v1/meetings/${meetingId}`);
+  const res = await apiClient.get<ApiResponse<MeetingDetail>>(`/v1/meetings/${meetingId}`);
   return res.data.data;
 }
 
@@ -11,7 +11,7 @@ export async function uploadRecording(meetingId: string, blob: Blob, durationSec
   const formData = new FormData();
   formData.append('file', blob, 'recording.webm');
   formData.append('durationSec', String(durationSec));
-  await apiClient.post(`/api/v1/meetings/${meetingId}/recording`, formData, {
+  await apiClient.post(`/v1/meetings/${meetingId}/recording`, formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
   });
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,31 @@
+import apiClient from './client';
+import type { User } from '@/types/user';
+
+interface MeApiData {
+  id: number;
+  email: string;
+  name: string;
+  role: 'LEADER' | 'MEMBER';
+  jobTitle: string;
+  teamId: number;
+  teamName: string;
+}
+
+interface MeApiResponse {
+  success: boolean;
+  data: MeApiData;
+}
+
+export async function fetchMe(): Promise<User> {
+  const { data } = await apiClient.get<MeApiResponse>('/api/v1/users/me');
+  const u = data.data;
+  return {
+    id: String(u.id),
+    email: u.email,
+    name: u.name,
+    role: u.role === 'LEADER' ? 'leader' : 'member',
+    jobTitle: u.jobTitle || undefined,
+    teamId: String(u.teamId),
+    teamName: u.teamName,
+  };
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -17,7 +17,7 @@ interface MeApiResponse {
 }
 
 export async function fetchMe(): Promise<User> {
-  const { data } = await apiClient.get<MeApiResponse>('/api/v1/users/me');
+  const { data } = await apiClient.get<MeApiResponse>('/v1/users/me');
   const u = data.data;
   return {
     id: String(u.id),

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -10,7 +10,7 @@ import MemberMeetingDetailPage from '@/pages/member/MeetingDetailPage';
 import SurveyPage from '@/pages/member/SurveyPage';
 
 const router = createBrowserRouter([
-  { path: '/', element: <Navigate to="/leader/dashboard" replace /> },
+  { path: '/', element: <Navigate to="/login" replace /> },
   { path: '/login', element: <LoginPage /> },
   { path: '/signup', element: <SignupPage /> },
   { path: '/leader/dashboard', element: <LeaderDashboard /> },
@@ -18,7 +18,6 @@ const router = createBrowserRouter([
   { path: '/leader/meeting/:meetingId', element: <LeaderMeetingDetailPage /> },
   { path: '/leader/promises', element: <PromiseLedgerPage /> },
   { path: '/leader/reports', element: <LeaderDashboard /> },
-  { path: '/leader/9box', element: <LeaderDashboard /> },
   { path: '/leader/overview', element: <LeaderDashboard /> },
   { path: '/member/dashboard', element: <MemberDashboard /> },
   { path: '/member/meeting/:meetingId', element: <MemberMeetingDetailPage /> },

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -82,9 +82,9 @@ const LogoutIcon = () => (
 );
 
 const navItems: NavItem[] = [
-  { label: '팀 인사이트 대시보드', path: '/leader/dashboard', icon: <BarChartIcon /> },
   { label: '1on1 미팅', path: '/leader/meetings', icon: <CalendarIcon /> },
   { label: '멤버 리포트', path: '/leader/reports', icon: <UsersIcon /> },
+  { label: '팀 인사이트 대시보드', path: '/leader/dashboard', icon: <BarChartIcon /> },
 ];
 
 const bottomItems = [

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,8 @@
-import { NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { useAuthStore } from '@/stores/authStore';
+import { useState, useRef, useEffect } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 import { useMeetingStore } from '@/stores/meetingStore';
-import { ROUTES } from '@/constants/routes';
+import { useMe } from '@/features/auth/useMe';
+import { useLogout } from '@/features/auth/useLogout';
 
 interface NavItem {
   label: string;
@@ -24,15 +25,6 @@ const UsersIcon = () => (
     <circle cx="9" cy="7" r="4" />
     <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
     <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-  </svg>
-);
-
-const GridIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <rect x="3" y="3" width="7" height="7" />
-    <rect x="14" y="3" width="7" height="7" />
-    <rect x="14" y="14" width="7" height="7" />
-    <rect x="3" y="14" width="7" height="7" />
   </svg>
 );
 
@@ -81,10 +73,18 @@ const ChevronRightIcon = () => (
   </svg>
 );
 
+const LogoutIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <polyline points="16 17 21 12 16 7" />
+    <line x1="21" y1="12" x2="9" y2="12" />
+  </svg>
+);
+
 const navItems: NavItem[] = [
   { label: '팀 인사이트 대시보드', path: '/leader/dashboard', icon: <BarChartIcon /> },
   { label: '1on1 미팅', path: '/leader/meetings', icon: <CalendarIcon /> },
-  { label: '멤버 리포트', path: '/leader/reports', icon: <UsersIcon /> }
+  { label: '멤버 리포트', path: '/leader/reports', icon: <UsersIcon /> },
 ];
 
 const bottomItems = [
@@ -95,9 +95,24 @@ const bottomItems = [
 export default function Sidebar() {
   const setCreateModalOpen = useMeetingStore((s) => s.setCreateModalOpen);
   const location = useLocation();
+  const user = useMe();
+  const { logout } = useLogout();
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const profileRef = useRef<HTMLDivElement>(null);
 
-  // "1on1 미팅" 네비게이션이 활성화되어야 하는 경로들
-  const isMeetingActive = location.pathname === '/leader/meetings' || location.pathname.startsWith('/leader/meeting/');
+  useEffect(() => {
+    if (!profileMenuOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (profileRef.current && !profileRef.current.contains(e.target as Node)) {
+        setProfileMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [profileMenuOpen]);
+
+  const isMeetingActive =
+    location.pathname === '/leader/meetings' || location.pathname.startsWith('/leader/meeting/');
 
   return (
     <aside
@@ -119,8 +134,8 @@ export default function Sidebar() {
 
       {/* New 1on1 Button */}
       <div className="px-4 pt-3 pb-2">
-        <button 
-          onClick={() => setCreateModalOpen(true)} // 클릭 시 전역 상태 변경
+        <button
+          onClick={() => setCreateModalOpen(true)}
           className="w-full py-2.5 bg-black text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-colors flex items-center justify-center gap-2"
         >
           새 1on1 만들기
@@ -130,9 +145,8 @@ export default function Sidebar() {
       {/* Nav */}
       <nav className="flex-1 px-3 pt-1 overflow-y-auto">
         {navItems.map((item) => {
-          // 1on1 미팅 아이템의 경우 특별한 활성화 로직 적용
-          const isActive = item.path === '/leader/meetings' ? isMeetingActive : location.pathname === item.path;
-          
+          const isActive =
+            item.path === '/leader/meetings' ? isMeetingActive : location.pathname === item.path;
           return (
             <NavLink
               key={item.path}
@@ -183,15 +197,39 @@ export default function Sidebar() {
       </div>
 
       {/* User Profile */}
-      <div className="px-4 py-3 border-t border-gray-100">
-        <div className="flex items-center gap-2">
-          <div className="w-7 h-7 rounded-full bg-emerald-500 flex items-center justify-center flex-shrink-0">
-            <span className="text-white text-xs font-semibold">G</span>
+      <div className="relative" ref={profileRef}>
+        {profileMenuOpen && (
+          <div className="absolute bottom-full left-4 right-4 mb-1 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden z-30">
+            <button
+              onClick={logout}
+              className="w-full px-4 py-2.5 text-sm text-left text-red-500 hover:bg-red-50 transition-colors flex items-center gap-2"
+            >
+              <LogoutIcon />
+              로그아웃
+            </button>
           </div>
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-gray-800 truncate">Guest</p>
-            <p className="text-xs text-gray-400 truncate">guest@readb.io</p>
-          </div>
+        )}
+        <div className="px-4 py-3 border-t border-gray-100">
+          <button
+            className="flex items-center gap-2 w-full rounded-lg hover:bg-gray-50 transition-colors px-1 py-0.5 disabled:cursor-default"
+            onClick={() => setProfileMenuOpen((prev) => !prev)}
+            disabled={!user}
+          >
+            <div className="w-7 h-7 rounded-full bg-emerald-500 flex items-center justify-center flex-shrink-0">
+              <span className="text-white text-xs font-semibold">
+                {user?.name?.[0] ?? '?'}
+              </span>
+            </div>
+            <div className="min-w-0 text-left">
+              <p className="text-sm font-medium text-gray-800 truncate">
+                {user?.name ?? '...'}
+              </p>
+              <p className="text-xs text-gray-400 truncate">{user?.email ?? ''}</p>
+              {user?.jobTitle && (
+                <p className="text-xs text-gray-400 truncate">{user.jobTitle}</p>
+              )}
+            </div>
+          </button>
         </div>
       </div>
     </aside>

--- a/src/components/loading/AnalysisLoading.tsx
+++ b/src/components/loading/AnalysisLoading.tsx
@@ -1,10 +1,12 @@
-import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { ANALYSIS_STEPS, WITTY_COPIES } from "./loadingCopies";
+import { useMeetingStatus } from "@/features/meeting/useMeetingStatus";
 import type { AnalysisStep } from "@/types/meeting";
 
 interface Props {
   role: "leader" | "member";
   recordingDuration?: number;
+  meetingId: string;
 }
 
 function formatDuration(s?: number) {
@@ -15,25 +17,47 @@ function formatDuration(s?: number) {
   return `${h}:${m}:${sec}`;
 }
 
-export default function AnalysisLoading({ role, recordingDuration }: Props) {
-  const [step, setStep] = useState<AnalysisStep>(0);
-  const [progress, setProgress] = useState(0);
+export default function AnalysisLoading({ role, recordingDuration, meetingId }: Props) {
+  const navigate = useNavigate();
+  const { status, error } = useMeetingStatus(meetingId, true);
   const copies = WITTY_COPIES[role];
 
-  useEffect(() => {
-    const iv = setInterval(() => {
-      setProgress((p) => {
-        if (p >= 100) { clearInterval(iv); return 100; }
-        const next = p + 0.5;
-        setStep(Math.min(3, Math.floor(next / 25)) as AnalysisStep);
-        return next;
-      });
-    }, 100);
-    return () => clearInterval(iv);
-  }, []);
+  const progress = status?.progress ?? 0;
+  const displayStep = Math.min(3, Math.max(0, (status?.stepNumber ?? 1) - 1)) as AnalysisStep;
+  const isCompleted = status?.step === 'COMPLETED';
 
   const r = 42;
   const circ = 2 * Math.PI * r;
+
+  if (error) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center px-8 gap-4">
+        <p className="text-base font-semibold text-red-500">{error}</p>
+        <button
+          onClick={() => navigate('/leader/meetings')}
+          className="px-5 py-2.5 rounded-lg border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
+        >
+          목록으로 돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  if (isCompleted) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center px-8 gap-4">
+        <p className="text-lg font-bold text-[#5F74FA]">분석이 완료되었습니다! 🎉</p>
+        <button
+          onClick={() => navigate('/leader/meetings')}
+          className="px-5 py-2.5 rounded-lg bg-[#5F74FA] text-sm text-white font-medium hover:bg-[#4E62E6]"
+        >
+          결과 보러 가기
+        </button>
+      </div>
+    );
+  }
+
+  const wittyMessage = status?.wittyMessage?.[role] ?? copies[displayStep];
 
   return (
     <div className="flex-1 flex flex-col">
@@ -97,16 +121,18 @@ export default function AnalysisLoading({ role, recordingDuration }: Props) {
               </div>
             </div>
             <p className="font-semibold text-sm">
-              {ANALYSIS_STEPS[step].icon} {ANALYSIS_STEPS[step].label}
+              {ANALYSIS_STEPS[displayStep].icon} {status?.stepLabel ?? ANALYSIS_STEPS[displayStep].label}
             </p>
-            <p className="text-xs text-gray-400">Step {step + 1} / 4</p>
+            <p className="text-xs text-gray-400">
+              Step {displayStep + 1} / {status?.totalSteps ?? 4}
+            </p>
           </div>
 
           {/* 단계 리스트 */}
           <div className="space-y-3 mb-6">
             {ANALYSIS_STEPS.map((s, i) => {
-              const active = i === step;
-              const done = i < step;
+              const active = i === displayStep;
+              const done = i < displayStep;
               return (
                 <div
                   key={i}
@@ -143,7 +169,7 @@ export default function AnalysisLoading({ role, recordingDuration }: Props) {
 
           {/* 위트 카피 */}
           <div className="bg-purple-50 rounded-xl p-4 text-center">
-            <p className="text-sm text-gray-600 italic">{copies[step]}</p>
+            <p className="text-sm text-gray-600 italic">{wittyMessage}</p>
           </div>
         </div>
       </div>

--- a/src/components/ui/CreateMeetingModal.tsx
+++ b/src/components/ui/CreateMeetingModal.tsx
@@ -67,7 +67,7 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
     }
     if (!user?.teamId) return;
     apiClient
-      .get<ApiResponse<TeamMemberApi[]>>(`/api/v1/teams/${user.teamId}/members`)
+      .get<ApiResponse<TeamMemberApi[]>>(`/v1/teams/${user.teamId}/members`)
       .then((res) => setMembers(res.data.data))
       .catch(() => setMembers([]));
   }, [isOpen, user?.teamId]);
@@ -104,7 +104,7 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
         return;
       }
       const res = await apiClient.post<ApiResponse<{ meetingId: number }>>(
-        "/api/v1/meetings",
+        "/v1/meetings",
         { memberId: selected.id, scheduledAt: `${selectedDate}T${selectedTime}:00` }
       );
       onCreated();

--- a/src/components/ui/CreateMeetingModal.tsx
+++ b/src/components/ui/CreateMeetingModal.tsx
@@ -11,6 +11,13 @@ interface TeamMemberApi {
   role: string;
 }
 
+const MOCK_MEMBERS: TeamMemberApi[] = [
+  { id: 1, name: "김민준", jobTitle: "프로덕트 매니저", role: "member" },
+  { id: 2, name: "이서연", jobTitle: "프론트엔드 개발자", role: "member" },
+  { id: 3, name: "박지호", jobTitle: "백엔드 개발자", role: "member" },
+  { id: 4, name: "최유나", jobTitle: "디자이너", role: "member" },
+];
+
 interface Props {
   isOpen: boolean;
   onClose: () => void;
@@ -53,7 +60,12 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
-    if (!isOpen || !user?.teamId) return;
+    if (!isOpen) return;
+    if (import.meta.env.VITE_USE_MOCK === 'true') {
+      setMembers(MOCK_MEMBERS);
+      return;
+    }
+    if (!user?.teamId) return;
     apiClient
       .get<ApiResponse<TeamMemberApi[]>>(`/api/v1/teams/${user.teamId}/members`)
       .then((res) => setMembers(res.data.data))
@@ -86,6 +98,11 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
     if (!selected) return;
     setIsSubmitting(true);
     try {
+      if (import.meta.env.VITE_USE_MOCK === 'true') {
+        onCreated();
+        navigate(`/leader/meeting/mock-${selected.id}`);
+        return;
+      }
       const res = await apiClient.post<ApiResponse<{ meetingId: number }>>(
         "/api/v1/meetings",
         { memberId: selected.id, scheduledAt: `${selectedDate}T${selectedTime}:00` }

--- a/src/features/auth/useLogin.ts
+++ b/src/features/auth/useLogin.ts
@@ -65,7 +65,7 @@ export function useLogin() {
         return authUser;
       }
 
-      const response = await apiClient.post<LoginApiResponse>('/api/v1/auth/login', {
+      const response = await apiClient.post<LoginApiResponse>('/v1/auth/login', {
         email: email.trim(),
         password,
       });

--- a/src/features/auth/useLogin.ts
+++ b/src/features/auth/useLogin.ts
@@ -17,6 +17,7 @@ interface LoginApiUser {
   email: string;
   name: string;
   role: ApiRole;
+  jobTitle?: string;
   teamId?: string | number | null;
 }
 
@@ -35,6 +36,7 @@ const toUser = (user: LoginApiUser): User => ({
   email: user.email,
   name: user.name,
   role: toUserRole(user.role),
+  jobTitle: user.jobTitle || undefined,
   teamId: user.teamId == null ? '' : String(user.teamId),
 });
 
@@ -54,6 +56,7 @@ export function useLogin() {
           email: email.trim(),
           name: '테스트 유저',
           role: 'leader',
+          jobTitle: 'FE 엔지니어',
           teamId: '1',
         };
 

--- a/src/features/auth/useLogin.ts
+++ b/src/features/auth/useLogin.ts
@@ -5,8 +5,6 @@ import type { User, UserRole } from '@/types/user';
 
 type ApiRole = 'LEADER' | 'MEMBER';
 
-const USE_MOCK_LOGIN = true;
-
 interface LoginRequest {
   email: string;
   password: string;
@@ -50,7 +48,7 @@ export function useLogin() {
     setError('');
 
     try {
-      if (USE_MOCK_LOGIN) {
+      if (import.meta.env.VITE_USE_MOCK === 'true') {
         const authUser: User = {
           id: '1',
           email: email.trim(),

--- a/src/features/auth/useLogout.ts
+++ b/src/features/auth/useLogout.ts
@@ -1,0 +1,15 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+
+export function useLogout() {
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+  const navigate = useNavigate();
+
+  const logout = () => {
+    clearAuth();
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+
+  return { logout };
+}

--- a/src/features/auth/useMe.ts
+++ b/src/features/auth/useMe.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useAuthStore } from '@/stores/authStore';
+import { fetchMe } from '@/api/user';
+
+export function useMe() {
+  const user = useAuthStore((s) => s.user);
+  const setAuth = useAuthStore((s) => s.setAuth);
+
+  useEffect(() => {
+    const { user: currentUser, token } = useAuthStore.getState();
+    if (currentUser !== null || !token) return;
+    fetchMe()
+      .then((me) => setAuth(me, token))
+      .catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return user;
+}

--- a/src/features/auth/useSignup.ts
+++ b/src/features/auth/useSignup.ts
@@ -5,8 +5,6 @@ import type { User, UserRole } from '@/types/user';
 
 export type SignupRole = 'LEADER' | 'MEMBER';
 
-const USE_MOCK_SIGNUP = false;
-
 interface SignupRequest {
   name: string;
   email: string;
@@ -64,7 +62,7 @@ export function useSignup() {
 
       console.log('signup payload', signupPayload);
 
-      if (USE_MOCK_SIGNUP) {
+      if (import.meta.env.VITE_USE_MOCK === 'true') {
         return null;
       }
 

--- a/src/features/auth/useSignup.ts
+++ b/src/features/auth/useSignup.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import axios from 'axios';
 import apiClient from '@/api/client';
 import { useAuthStore } from '@/stores/authStore';
 import type { User, UserRole } from '@/types/user';
@@ -84,8 +85,10 @@ export function useSignup() {
       }
 
       return null;
-    } catch {
-      const message = '회원 가입에 실패했습니다.';
+    } catch (err) {
+      const serverMessage =
+        axios.isAxiosError(err) ? err.response?.data?.message : undefined;
+      const message = serverMessage || '회원 가입에 실패했습니다.';
       setError(message);
       throw new Error(message);
     } finally {

--- a/src/features/auth/useSignup.ts
+++ b/src/features/auth/useSignup.ts
@@ -5,7 +5,7 @@ import type { User, UserRole } from '@/types/user';
 
 export type SignupRole = 'LEADER' | 'MEMBER';
 
-const USE_MOCK_SIGNUP = true;
+const USE_MOCK_SIGNUP = false;
 
 interface SignupRequest {
   name: string;
@@ -68,7 +68,7 @@ export function useSignup() {
         return null;
       }
 
-      const response = await apiClient.post<SignupApiResponse>('/api/v1/auth/signup', signupPayload);
+      const response = await apiClient.post<SignupApiResponse>('/v1/auth/signup', signupPayload);
 
       if (response.data?.success === false) {
         throw new Error(response.data.message || '회원 가입에 실패했습니다.');

--- a/src/features/meeting/useMeetingDetail.ts
+++ b/src/features/meeting/useMeetingDetail.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { fetchMeetingDetail } from '@/api/meetings';
 import type { MeetingDetail } from '@/types/meeting';
-
+// 테스트용 데이터(백엔드 연결 시 삭제)
 const MOCK_MEETING: MeetingDetail = {
   meetingId: 0,
   round: 1,
@@ -22,6 +22,7 @@ export function useMeetingDetail(meetingId: string | undefined) {
       setLoading(false);
       return;
     }
+    // 테스트 조건, 백엔드 정상 연결 시 삭제
     if (import.meta.env.VITE_USE_MOCK === 'true' && meetingId.startsWith('mock-')) {
       setMeeting(MOCK_MEETING);
       setLoading(false);

--- a/src/features/meeting/useMeetingDetail.ts
+++ b/src/features/meeting/useMeetingDetail.ts
@@ -2,6 +2,16 @@ import { useState, useEffect } from 'react';
 import { fetchMeetingDetail } from '@/api/meetings';
 import type { MeetingDetail } from '@/types/meeting';
 
+const MOCK_MEETING: MeetingDetail = {
+  meetingId: 0,
+  round: 1,
+  scheduledAt: new Date().toISOString(),
+  durationSec: null,
+  status: 'PENDING',
+  leaderName: '나 (리더)',
+  memberName: '김민준',
+};
+
 export function useMeetingDetail(meetingId: string | undefined) {
   const [meeting, setMeeting] = useState<MeetingDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -9,6 +19,11 @@ export function useMeetingDetail(meetingId: string | undefined) {
 
   useEffect(() => {
     if (!meetingId) {
+      setLoading(false);
+      return;
+    }
+    if (import.meta.env.VITE_USE_MOCK === 'true' && meetingId.startsWith('mock-')) {
+      setMeeting(MOCK_MEETING);
       setLoading(false);
       return;
     }

--- a/src/features/meeting/useMeetingStatus.ts
+++ b/src/features/meeting/useMeetingStatus.ts
@@ -1,28 +1,48 @@
-import { useEffect, useRef } from "react";
-import { useMeetingStore } from "@/stores/meetingStore";
+import { useState, useEffect, useRef } from "react";
+import { fetchAnalysisStatus } from "@/api/analysis";
+import type { AnalysisStatusData } from "@/types/analysis";
 
-/**
- * 분석 상태를 폴링하여 "analyzing" → "completed" 전환을 감지
- * TODO: 실제 API 폴링으로 교체
- */
-export function useMeetingStatus(meetingId: string | null) {
-  const updateStatus = useMeetingStore((s) => s.updateMeetingStatus);
+const POLL_INTERVAL_MS = 3000;
+const TIMEOUT_MS = 180_000;
+
+export function useMeetingStatus(meetingId: string | null, active: boolean) {
+  const [status, setStatus] = useState<AnalysisStatusData | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startTimeRef = useRef<number>(0);
 
   useEffect(() => {
-    if (!meetingId) return;
+    if (!meetingId || !active) return;
 
-    // 데모용: 20초 후 completed 전환 (실제로는 BE 폴링)
-    intervalRef.current = setInterval(() => {
-      // const res = await apiClient.get(`/meetings/${meetingId}/status`);
-      // if (res.data.status === "completed") {
-      //   updateStatus(meetingId, "completed");
-      //   clearInterval(intervalRef.current!);
-      // }
-    }, 3000);
+    startTimeRef.current = Date.now();
+
+    const poll = async () => {
+      if (Date.now() - startTimeRef.current > TIMEOUT_MS) {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        setError('분석 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.');
+        return;
+      }
+      try {
+        const data = await fetchAnalysisStatus(meetingId);
+        setStatus(data);
+        if (data.step === 'COMPLETED' || data.step === 'FAILED') {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          if (data.step === 'FAILED') {
+            setError('분석에 실패했습니다. 잠시 후 다시 시도해주세요.');
+          }
+        }
+      } catch {
+        // 일시적 네트워크 오류는 무시하고 계속 폴링
+      }
+    };
+
+    poll();
+    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
 
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [meetingId, updateStatus]);
+  }, [meetingId, active]);
+
+  return { status, error };
 }

--- a/src/features/meeting/useRecorder.ts
+++ b/src/features/meeting/useRecorder.ts
@@ -11,6 +11,8 @@ export function useRecorder() {
   const analyserRef = useRef<AnalyserNode | null>(null);
   const rafRef = useRef<number | null>(null);
   const blobRef = useRef<Blob | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const elapsedRef = useRef(0);
 
   const tickAudioLevel = useCallback(() => {
     if (!analyserRef.current) return;
@@ -27,6 +29,7 @@ export function useRecorder() {
 
   const start = useCallback(async () => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    streamRef.current = stream;
 
     const ctx = new AudioContext();
     const source = ctx.createMediaStreamSource(stream);
@@ -35,33 +38,51 @@ export function useRecorder() {
     source.connect(analyser);
     analyserRef.current = analyser;
 
-    const mr = new MediaRecorder(stream, { mimeType: "audio/webm" });
+    const mr = new MediaRecorder(stream, {
+      mimeType: "audio/webm",
+      audioBitsPerSecond: 16000,
+    });
     chunksRef.current = [];
     mr.ondataavailable = (e) => {
       if (e.data.size > 0) chunksRef.current.push(e.data);
-    };
-    mr.onstop = () => {
-      blobRef.current = new Blob(chunksRef.current, { type: "audio/webm" });
-      stream.getTracks().forEach((t) => t.stop());
     };
 
     recorderRef.current = mr;
     mr.start(1000);
     setIsRecording(true);
     setElapsed(0);
-    timerRef.current = setInterval(() => setElapsed((t) => t + 1), 1000);
+    elapsedRef.current = 0;
+    timerRef.current = setInterval(() => {
+      setElapsed((t) => {
+        const next = t + 1;
+        elapsedRef.current = next;
+        return next;
+      });
+    }, 1000);
     rafRef.current = requestAnimationFrame(tickAudioLevel);
   }, [tickAudioLevel]);
 
-  const stop = useCallback(() => {
-    recorderRef.current?.stop();
-    if (timerRef.current) clearInterval(timerRef.current);
-    if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    setIsRecording(false);
-    setAudioLevel(0);
+  const stop = useCallback((): Promise<{ blob: Blob; durationSec: number }> => {
+    return new Promise((resolve, reject) => {
+      const recorder = recorderRef.current;
+      if (!recorder) {
+        reject(new Error('녹음이 시작되지 않았습니다.'));
+        return;
+      }
+      const durationSec = elapsedRef.current;
+      recorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        blobRef.current = blob;
+        streamRef.current?.getTracks().forEach((t) => t.stop());
+        resolve({ blob, durationSec });
+      };
+      recorder.stop();
+      if (timerRef.current) clearInterval(timerRef.current);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      setIsRecording(false);
+      setAudioLevel(0);
+    });
   }, []);
 
-  const getBlob = useCallback(() => blobRef.current, []);
-
-  return { isRecording, elapsed, audioLevel, start, stop, getBlob };
+  return { isRecording, elapsed, audioLevel, start, stop };
 }

--- a/src/features/meeting/useUploadRecording.ts
+++ b/src/features/meeting/useUploadRecording.ts
@@ -13,6 +13,7 @@ export function useUploadRecording() {
       setError(msg);
       throw new Error(msg);
     }
+    // 테스트 조건, 백엔드 정상 연결 시 삭제
     if (import.meta.env.VITE_USE_MOCK === 'true' && meetingId.startsWith('mock-')) {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/src/features/meeting/useUploadRecording.ts
+++ b/src/features/meeting/useUploadRecording.ts
@@ -13,6 +13,16 @@ export function useUploadRecording() {
       setError(msg);
       throw new Error(msg);
     }
+    if (import.meta.env.VITE_USE_MOCK === 'true' && meetingId.startsWith('mock-')) {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `recording-${meetingId}-${durationSec}s.webm`;
+      a.click();
+      URL.revokeObjectURL(url);
+      await new Promise((r) => setTimeout(r, 1500));
+      return;
+    }
     setIsUploading(true);
     setError(null);
     try {

--- a/src/features/meeting/useUploadRecording.ts
+++ b/src/features/meeting/useUploadRecording.ts
@@ -1,23 +1,30 @@
 import { useState, useCallback } from "react";
+import { uploadRecording } from "@/api/meetings";
+
+const MAX_FILE_SIZE = 25 * 1024 * 1024;
 
 export function useUploadRecording() {
   const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const upload = useCallback(async (meetingId: string, blob: Blob) => {
+  const upload = useCallback(async (meetingId: string, blob: Blob, durationSec: number) => {
+    if (blob.size > MAX_FILE_SIZE) {
+      const msg = '녹음 파일이 너무 큽니다. (25MB 초과)';
+      setError(msg);
+      throw new Error(msg);
+    }
     setIsUploading(true);
+    setError(null);
     try {
-      const formData = new FormData();
-      formData.append("file", blob, `meeting-${meetingId}.webm`);
-      formData.append("meetingId", meetingId);
-
-      // TODO: 실제 API 엔드포인트로 교체
-      // await apiClient.post("/meetings/upload", formData);
-
-      console.log("[useUploadRecording] uploaded", meetingId, blob.size, "bytes");
+      await uploadRecording(meetingId, blob, durationSec);
+    } catch {
+      const msg = '녹음 파일 업로드에 실패했습니다.';
+      setError(msg);
+      throw new Error(msg);
     } finally {
       setIsUploading(false);
     }
   }, []);
 
-  return { upload, isUploading };
+  return { upload, isUploading, error };
 }

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -25,6 +25,7 @@ const initialForm: SignupForm = {
 };
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/;
 const roleOptions: Array<{ label: string; value: Role }> = [
   { label: '리더', value: 'LEADER' },
   { label: '멤버', value: 'MEMBER' },
@@ -52,6 +53,10 @@ export default function SignupPage() {
 
     if (!emailPattern.test(email.trim())) {
       return '올바른 이메일 형식을 입력해주세요.';
+    }
+
+    if (!passwordPattern.test(password)) {
+      return '비밀번호는 8자 이상, 영문·숫자·특수문자를 포함해야 합니다.';
     }
 
     if (password !== passwordConfirm) {
@@ -91,12 +96,8 @@ export default function SignupPage() {
       setMessageType('success');
       window.setTimeout(() => navigate('/login'), 1000);
     } catch (error) {
-      const serverMessage =
-        error && typeof error === 'object' && 'response' in error
-          ? (error.response as { data?: { message?: string } })?.data?.message
-          : '';
-
-      setMessage(serverMessage || '회원 가입에 실패했습니다.');
+      const message = error instanceof Error ? error.message : '회원 가입에 실패했습니다.';
+      setMessage(message);
       setMessageType('error');
     }
   };
@@ -138,6 +139,7 @@ export default function SignupPage() {
               placeholder="비밀번호를 입력하세요"
               autoComplete="new-password"
             />
+            <p className="mt-1 text-xs text-gray-400">8자 이상, 영문·숫자·특수문자를 포함해야 합니다.</p>
           </label>
 
           <label className="block">

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import PageLayout from "@/components/layout/PageLayout";
 import { useRecorder } from "@/features/meeting/useRecorder";
@@ -10,7 +10,7 @@ import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
 import AnalysisLoading from "@/components/loading/AnalysisLoading";
 import type { MeetingDetail } from "@/types/meeting";
 
-type LocalStatus = "pending" | "recording" | "analyzing";
+type LocalStatus = "pending" | "recording" | "uploading" | "analyzing" | "error";
 
 export default function MeetingDetailPage() {
   const { meetingId } = useParams<{ meetingId: string }>();
@@ -21,6 +21,8 @@ export default function MeetingDetailPage() {
   const [showStart, setShowStart] = useState(false);
   const [showEnd, setShowEnd] = useState(false);
   const [localStatus, setLocalStatus] = useState<LocalStatus>("pending");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const pendingUploadRef = useRef<{ blob: Blob; durationSec: number } | null>(null);
 
   useEffect(() => {
     if (meeting?.status === "ANALYZING" || meeting?.status === "RECORDING") {
@@ -33,15 +35,32 @@ export default function MeetingDetailPage() {
     setLocalStatus("recording");
   }, [recorder]);
 
-  const handleEndMeeting = useCallback(() => {
-    recorder.stop();
-    setLocalStatus("analyzing");
+  const performUpload = useCallback(async (id: string, blob: Blob, durationSec: number) => {
+    setLocalStatus("uploading");
+    setUploadError(null);
+    try {
+      await upload(id, blob, durationSec);
+      setLocalStatus("analyzing");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : '업로드에 실패했습니다.';
+      setUploadError(msg);
+      setLocalStatus("error");
+    }
+  }, [upload]);
+
+  const handleEndMeeting = useCallback(async () => {
+    if (!meetingId) return;
     setShowEnd(false);
-    setTimeout(() => {
-      const blob = recorder.getBlob();
-      if (blob && meetingId) upload(meetingId, blob);
-    }, 500);
-  }, [recorder, meetingId, upload]);
+    const { blob, durationSec } = await recorder.stop();
+    pendingUploadRef.current = { blob, durationSec };
+    await performUpload(meetingId, blob, durationSec);
+  }, [meetingId, recorder, performUpload]);
+
+  const handleRetry = useCallback(async () => {
+    if (!meetingId || !pendingUploadRef.current) return;
+    const { blob, durationSec } = pendingUploadRef.current;
+    await performUpload(meetingId, blob, durationSec);
+  }, [meetingId, performUpload]);
 
   if (loading) {
     return (
@@ -72,12 +91,53 @@ export default function MeetingDetailPage() {
     );
   }
 
+  if (localStatus === "uploading") {
+    return (
+      <PageLayout>
+        <div className="flex flex-col">
+          <MeetingHeader meeting={meeting} />
+          <div className="flex-1 flex flex-col items-center justify-center px-8 gap-4">
+            <div className="w-10 h-10 border-4 border-[#5F74FA] border-t-transparent rounded-full animate-spin" />
+            <p className="text-sm text-gray-600">녹음 파일을 업로드 중입니다...</p>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (localStatus === "error") {
+    return (
+      <PageLayout>
+        <div className="flex flex-col">
+          <MeetingHeader meeting={meeting} />
+          <div className="flex-1 flex flex-col items-center justify-center px-8 gap-4">
+            <p className="text-base font-semibold text-red-500">
+              {uploadError ?? '오류가 발생했습니다.'}
+            </p>
+            <button
+              onClick={handleRetry}
+              className="px-5 py-2.5 rounded-lg bg-[#5F74FA] text-sm text-white font-medium hover:bg-[#4E62E6]"
+            >
+              다시 시도
+            </button>
+            <button
+              onClick={() => navigate('/leader/meetings')}
+              className="px-5 py-2.5 rounded-lg border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
+            >
+              목록으로 돌아가기
+            </button>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
   if (localStatus === "analyzing") {
     return (
       <PageLayout>
         <div className="flex flex-col">
           <MeetingHeader meeting={meeting} />
-          <AnalysisLoading role="leader" recordingDuration={recorder.elapsed} />
+          <AnalysisLoading role="leader" recordingDuration={recorder.elapsed} meetingId={meetingId!} />
         </div>
       </PageLayout>
     );

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -1,17 +1,33 @@
+export type AnalysisStepKey = 'PENDING' | 'STT' | 'NLP' | 'SCORING' | 'FEEDBACK' | 'COMPLETED' | 'FAILED';
+
+// 분석 상태 데이터 인터페이스
+export interface AnalysisStatusData {
+  meetingId: number;
+  step: AnalysisStepKey;
+  stepNumber: number;
+  totalSteps: number;
+  progress: number;
+  stepLabel: string;
+  wittyMessage: {
+    leader: string;
+    member: string;
+  };
+}
+// 레이더 차트용 인터페이스
 export interface RadarMember {
   memberId: string;
   name: string;
   surfaceScore: number;
   inferredScore: number;
 }
-
+// 액션 아이템 우선순위 인터페이스
 export interface ActionItem {
   id: string;
   title: string;
   description: string;
   priority: 'high' | 'medium' | 'low';
 }
-
+// 발화 비율 인터페이스
 export interface CommunicationBalance {
   memberId: string;
   name: string;
@@ -19,7 +35,7 @@ export interface CommunicationBalance {
   leaderRatio: number;
   status: '위험' | '적정' | '관찰';
 }
-
+// 팀 통계 인터페이스
 export interface TeamStats {
   motivationIndex: number;
   motivationDelta: number;

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -22,7 +22,7 @@ export interface MeetingData {
   partner: TeamMember;
   partnerRole: "leader" | "member";
   myRole: "leader" | "member";
-  status: "pending" | "recording" | "analyzing" | "completed";
+  status: "pending" | "recording" | "uploading" | "analyzing" | "completed" | "error";
   recordingDuration?: number;
 }
 
@@ -31,9 +31,9 @@ export type AnalysisStep = 0 | 1 | 2 | 3;
 export interface MeetingDetail {
   meetingId: number;
   round: number;
-  scheduledAt: string;          // ISO 8601, 예: "2026-05-08T14:00:00"
+  scheduledAt: string;
   durationSec: number | null;
-  status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED"; // 백엔드 API 응답값 (대문자)
+  status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
   leaderName: string;
   memberName: string;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -5,5 +5,7 @@ export interface User {
   email: string
   name: string
   role: UserRole
+  jobTitle?: string
   teamId: string
+  teamName?: string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,12 @@
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary

- 로그인/회원가입 API 경로를 실제 백엔드 주소(`/v1/auth/...`)로 수정하고, MOCK 분기를 `VITE_USE_MOCK` 환경변수로 통일
- `useMe` 훅 추가 — 토큰은 있지만 user 정보가 없을 때 `/v1/users/me`를 호출해 스토어에 저장
- `useLogout` 훅 추가 — clearAuth + localStorage 토큰 제거 + `/login` 리다이렉트
- 사이드바 프로필 영역을 실제 사용자 이름·이메일·직함으로 교체, 클릭 시 로그아웃 팝업 표시
- 서비스 진입점(`/`)을 `/leader/dashboard` 대신 `/login`으로 변경
- 회원가입 비밀번호 조건 검증(8자 이상, 영문·숫자·특수문자) 및 서버 에러 메시지 전달 개선
- 녹음 업로드·분석 상태 폴링 실제 API 연동 (`useUploadRecording`, `useMeetingStatus`)

## Changed Files

| 파일 | 변경 내용 |
|------|-----------|
| `src/api/user.ts` | 신규 — `/v1/users/me` 호출, 응답을 `User` 타입으로 변환 |
| `src/features/auth/useMe.ts` | 신규 — 토큰 보유 시 사용자 정보 자동 복원 |
| `src/features/auth/useLogout.ts` | 신규 — 로그아웃 처리 |
| `src/features/auth/useLogin.ts` | API 경로 수정, MOCK 분기 환경변수화, `jobTitle` 추가 |
| `src/features/auth/useSignup.ts` | API 경로 수정, MOCK 분기 환경변수화, 서버 에러 메시지 전달 |
| `src/pages/auth/SignupPage.tsx` | 비밀번호 패턴 검증 추가, 에러 메시지 처리 개선 |
| `src/components/layout/Sidebar.tsx` | 실제 사용자 정보 표시, 로그아웃 팝업 구현 |
| `src/app/router.tsx` | 진입 경로 `/` → `/login` 변경 |
| `src/features/meeting/useUploadRecording.ts` | 녹음 업로드 실제 API 연동 |
| `src/features/meeting/useMeetingStatus.ts` | 분석 상태 폴링 실제 API 연동 |

## Test Checklist

- [ ] 로그인 → 사이드바에 실제 이름/이메일 표시 확인
- [ ] 새로고침 후 토큰 유지 시 사용자 정보 복원 확인
- [ ] 로그아웃 → `/login` 이동 및 토큰 삭제 확인
- [ ] 회원가입 시 비밀번호 조건 미충족 에러 메시지 확인
- [ ] `VITE_USE_MOCK=true` 환경에서 mock 동작 정상 확인