### PR TITLE
feat: team setup flow and build error fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,14 @@ Meeting status progression: `pending → recording → analyzing → completed`.
 /leader/reports, /leader/9box, /leader/overview, /settings, /invite → all stub to LeaderDashboard
 ```
 
+## API URL Convention
+
+- Omit the `/api` prefix when writing API endpoint paths. The base URL already includes it via `VITE_API_BASE_URL`. Write `/meetings/upload`, not `/api/meetings/upload`.
+
+## Workflow
+
+- All output produced by Claude must be reviewed by another AI agent before being considered final.
+
 ## Shared File Rules
 
 - `types/` and `constants/` — additions only; renames/deletes require team notification.

--- a/docs/superpowers/plans/2026-05-20-team-setup.md
+++ b/docs/superpowers/plans/2026-05-20-team-setup.md
@@ -1,0 +1,598 @@
+# Team Setup Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 팀에 소속되지 않은 사용자(`teamId === ''`)가 대시보드 대신 팀 생성(리더) 또는 팀 참여(멤버) 화면으로 자동 리다이렉트되도록 구현한다.
+
+**Architecture:** 이중 보호 전략 — LoginPage/SignupPage에서 로그인 직후 `teamId` 체크 후 분기, `RequiresTeam` 컴포넌트로 모든 보호 라우트를 감싸 URL 직접 입력도 차단. 팀 생성/참여 성공 후 `fetchMe()`로 authStore를 최신 상태로 갱신.
+
+**Tech Stack:** React 18, React Router v6, Zustand, Axios, TypeScript, Tailwind CSS
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `src/types/user.ts` | `teamName?: string` 필드 추가 |
+| Create | `src/api/user.ts` | `fetchMe()` — GET /api/v1/users/me |
+| Create | `src/api/teams.ts` | `createTeam()`, `joinTeam()` |
+| Create | `src/features/team/useCreateTeam.ts` | 팀 생성 훅 |
+| Create | `src/features/team/useJoinTeam.ts` | 팀 참여 훅 |
+| Create | `src/features/auth/RequiresTeam.tsx` | 라우트 가드 컴포넌트 |
+| Create | `src/pages/leader/TeamSetupPage.tsx` | 리더 팀 생성 페이지 |
+| Create | `src/pages/member/TeamJoinPage.tsx` | 멤버 팀 참여 페이지 |
+| Modify | `src/app/router.tsx` | RequiresTeam 래퍼, 신규 라우트 추가 |
+| Modify | `src/pages/auth/LoginPage.tsx` | teamId 체크 후 분기 |
+| Modify | `src/pages/auth/SignupPage.tsx` | 회원가입 후 직접 팀 셋업으로 이동 |
+
+---
+
+### Task 1: Types + API Layer
+
+**Files:**
+- Modify: `src/types/user.ts`
+- Create: `src/api/user.ts`
+- Create: `src/api/teams.ts`
+
+- [ ] **Step 1: `teamName` 필드를 `User` 타입에 추가**
+
+`src/types/user.ts`를 아래와 같이 수정:
+
+```ts
+export type UserRole = 'leader' | 'member'
+
+export interface User {
+  id: string
+  email: string
+  name: string
+  role: UserRole
+  teamId: string
+  teamName?: string
+}
+```
+
+- [ ] **Step 2: `src/api/user.ts` 생성**
+
+```ts
+import apiClient from './client';
+import type { ApiResponse } from './types';
+import type { User, UserRole } from '@/types/user';
+
+interface MeApiUser {
+  id: string | number;
+  email: string;
+  name: string;
+  role: 'LEADER' | 'MEMBER';
+  teamId?: string | number | null;
+  teamName?: string | null;
+}
+
+const toUser = (u: MeApiUser): User => ({
+  id: String(u.id),
+  email: u.email,
+  name: u.name,
+  role: (u.role === 'LEADER' ? 'leader' : 'member') as UserRole,
+  teamId: u.teamId == null ? '' : String(u.teamId),
+  teamName: u.teamName ?? undefined,
+});
+
+export async function fetchMe(): Promise<User> {
+  const res = await apiClient.get<ApiResponse<MeApiUser>>('/api/v1/users/me');
+  return toUser(res.data.data);
+}
+```
+
+- [ ] **Step 3: `src/api/teams.ts` 생성**
+
+```ts
+import apiClient from './client';
+import type { ApiResponse } from './types';
+
+interface CreateTeamApiResponse {
+  id: string | number;
+  name: string;
+  leaderId: string | number;
+  leaderName: string;
+  inviteCode: string;
+}
+
+interface JoinTeamApiResponse {
+  teamId: string | number;
+  teamName: string;
+}
+
+export interface CreateTeamResult {
+  id: string;
+  name: string;
+  inviteCode: string;
+}
+
+export interface JoinTeamResult {
+  teamId: string;
+  teamName: string;
+}
+
+export async function createTeam(name: string): Promise<CreateTeamResult> {
+  const res = await apiClient.post<ApiResponse<CreateTeamApiResponse>>('/api/v1/teams', { name });
+  const d = res.data.data;
+  return { id: String(d.id), name: d.name, inviteCode: d.inviteCode };
+}
+
+export async function joinTeam(inviteCode: string): Promise<JoinTeamResult> {
+  const res = await apiClient.post<ApiResponse<JoinTeamApiResponse>>('/api/v1/teams/join', { inviteCode });
+  const d = res.data.data;
+  return { teamId: String(d.teamId), teamName: d.teamName };
+}
+```
+
+- [ ] **Step 4: 타입 체크**
+
+실행: `npm run type-check`  
+기대 결과: 에러 없음
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/user.ts src/api/user.ts src/api/teams.ts
+git commit -m "feat: add teamName to User type and create teams/user API functions"
+```
+
+---
+
+### Task 2: Feature Hooks
+
+**Files:**
+- Create: `src/features/team/useCreateTeam.ts`
+- Create: `src/features/team/useJoinTeam.ts`
+
+- [ ] **Step 1: `src/features/team/useCreateTeam.ts` 생성**
+
+```ts
+import { useState } from 'react';
+import { createTeam } from '@/api/teams';
+import { fetchMe } from '@/api/user';
+import { useAuthStore } from '@/stores/authStore';
+
+export function useCreateTeam() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const token = useAuthStore((s) => s.token);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const create = async (name: string): Promise<string> => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const result = await createTeam(name);
+      const freshUser = await fetchMe();
+      setAuth(freshUser, token ?? '');
+      return result.inviteCode;
+    } catch {
+      const message = '팀 생성에 실패했습니다.';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { create, isLoading, error };
+}
+```
+
+- [ ] **Step 2: `src/features/team/useJoinTeam.ts` 생성**
+
+```ts
+import { useState } from 'react';
+import { joinTeam } from '@/api/teams';
+import { fetchMe } from '@/api/user';
+import { useAuthStore } from '@/stores/authStore';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  TEAM_NOT_FOUND: '유효하지 않은 초대 코드입니다.',
+  ALREADY_IN_TEAM: '이미 팀에 소속되어 있습니다.',
+};
+
+export function useJoinTeam() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const token = useAuthStore((s) => s.token);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const join = async (inviteCode: string): Promise<string> => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const result = await joinTeam(inviteCode);
+      const freshUser = await fetchMe();
+      setAuth(freshUser, token ?? '');
+      return result.teamName;
+    } catch (err) {
+      const code =
+        err && typeof err === 'object' && 'response' in err
+          ? (err.response as { data?: { code?: string } })?.data?.code
+          : undefined;
+      const message = (code && ERROR_MESSAGES[code]) ?? '팀 참여에 실패했습니다.';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { join, isLoading, error };
+}
+```
+
+- [ ] **Step 3: 타입 체크**
+
+실행: `npm run type-check`  
+기대 결과: 에러 없음
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/team/useCreateTeam.ts src/features/team/useJoinTeam.ts
+git commit -m "feat: add useCreateTeam and useJoinTeam hooks"
+```
+
+---
+
+### Task 3: RequiresTeam Route Guard
+
+**Files:**
+- Create: `src/features/auth/RequiresTeam.tsx`
+
+- [ ] **Step 1: `src/features/auth/RequiresTeam.tsx` 생성**
+
+```tsx
+import { type ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function RequiresTeam({ children }: Props) {
+  const token = useAuthStore((s) => s.token);
+  const user = useAuthStore((s) => s.user);
+
+  if (!token) return <Navigate to="/login" replace />;
+  if (!user) return null;
+  if (user.teamId === '') {
+    return <Navigate to={user.role === 'leader' ? '/leader/team-setup' : '/member/team-join'} replace />;
+  }
+
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 2: 타입 체크**
+
+실행: `npm run type-check`  
+기대 결과: 에러 없음
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/auth/RequiresTeam.tsx
+git commit -m "feat: add RequiresTeam route guard component"
+```
+
+---
+
+### Task 4: TeamSetupPage
+
+**Files:**
+- Create: `src/pages/leader/TeamSetupPage.tsx`
+
+- [ ] **Step 1: `src/pages/leader/TeamSetupPage.tsx` 생성**
+
+```tsx
+import { type FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Modal from '@/components/ui/Modal';
+import { useCreateTeam } from '@/features/team/useCreateTeam';
+
+export default function TeamSetupPage() {
+  const navigate = useNavigate();
+  const { create, isLoading, error } = useCreateTeam();
+  const [teamName, setTeamName] = useState('');
+  const [inviteCode, setInviteCode] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = teamName.trim();
+    if (trimmed.length < 2 || trimmed.length > 30) return;
+    try {
+      const code = await create(trimmed);
+      setInviteCode(code);
+      setModalOpen(true);
+    } catch {
+      // error is set in hook
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(inviteCode).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const handleConfirm = () => {
+    setModalOpen(false);
+    navigate('/leader/dashboard');
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6">
+      <section className="w-full max-w-sm">
+        <h1 className="mb-2 text-center text-3xl font-bold text-black">팀 만들기</h1>
+        <p className="mb-8 text-center text-sm text-gray-500">팀 이름을 입력하고 팀을 생성하세요.</p>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">팀 이름</span>
+            <Input
+              type="text"
+              value={teamName}
+              onChange={(e) => setTeamName(e.target.value)}
+              placeholder="팀 이름을 입력하세요 (2~30자)"
+              minLength={2}
+              maxLength={30}
+            />
+          </label>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <Button type="submit" className="w-full" disabled={isLoading || teamName.trim().length < 2}>
+            {isLoading ? '생성 중...' : '팀 생성하기'}
+          </Button>
+        </form>
+
+        <Modal open={modalOpen} onClose={() => {}}>
+          <h2 className="mb-4 text-lg font-bold text-black">팀이 생성되었습니다!</h2>
+          <p className="mb-2 text-sm text-gray-600">아래 초대 코드를 팀원에게 공유하세요.</p>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="mb-4 w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-center font-mono text-lg font-semibold tracking-widest text-black hover:bg-gray-100"
+          >
+            {inviteCode}
+          </button>
+          {copied && <p className="mb-2 text-center text-xs text-green-600">클립보드에 복사되었습니다.</p>}
+          <Button className="w-full" onClick={handleConfirm}>
+            확인
+          </Button>
+        </Modal>
+      </section>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: 타입 체크**
+
+실행: `npm run type-check`  
+기대 결과: 에러 없음
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/leader/TeamSetupPage.tsx
+git commit -m "feat: add TeamSetupPage for leader team creation"
+```
+
+---
+
+### Task 5: TeamJoinPage
+
+**Files:**
+- Create: `src/pages/member/TeamJoinPage.tsx`
+
+- [ ] **Step 1: `src/pages/member/TeamJoinPage.tsx` 생성**
+
+```tsx
+import { type FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Modal from '@/components/ui/Modal';
+import { useJoinTeam } from '@/features/team/useJoinTeam';
+
+export default function TeamJoinPage() {
+  const navigate = useNavigate();
+  const { join, isLoading, error } = useJoinTeam();
+  const [inviteCode, setInviteCode] = useState('');
+  const [joinedTeamName, setJoinedTeamName] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = inviteCode.trim();
+    if (!trimmed) return;
+    try {
+      const teamName = await join(trimmed);
+      setJoinedTeamName(teamName);
+      setModalOpen(true);
+    } catch {
+      // error is set in hook
+    }
+  };
+
+  const handleConfirm = () => {
+    setModalOpen(false);
+    navigate('/member/dashboard');
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6">
+      <section className="w-full max-w-sm">
+        <h1 className="mb-2 text-center text-3xl font-bold text-black">팀 참여하기</h1>
+        <p className="mb-8 text-center text-sm text-gray-500">리더에게 받은 초대 코드를 입력하세요.</p>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">초대 코드</span>
+            <Input
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              placeholder="초대 코드를 입력하세요"
+            />
+          </label>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <Button type="submit" className="w-full" disabled={isLoading || !inviteCode.trim()}>
+            {isLoading ? '참여 중...' : '참여하기'}
+          </Button>
+        </form>
+
+        <Modal open={modalOpen} onClose={() => {}}>
+          <h2 className="mb-4 text-lg font-bold text-black">{joinedTeamName}에 참여했습니다.</h2>
+          <Button className="w-full" onClick={handleConfirm}>
+            확인
+          </Button>
+        </Modal>
+      </section>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: 타입 체크**
+
+실행: `npm run type-check`  
+기대 결과: 에러 없음
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/member/TeamJoinPage.tsx
+git commit -m "feat: add TeamJoinPage for member team joining"
+```
+
+---
+
+### Task 6: Wire Up — Router + Auth Pages
+
+**Files:**
+- Modify: `src/app/router.tsx`
+- Modify: `src/pages/auth/LoginPage.tsx`
+- Modify: `src/pages/auth/SignupPage.tsx`
+
+- [ ] **Step 1: `src/app/router.tsx` 전체 교체**
+
+```tsx
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import RequiresTeam from '@/features/auth/RequiresTeam';
+import LoginPage from '@/pages/auth/LoginPage';
+import SignupPage from '@/pages/auth/SignupPage';
+import LeaderDashboard from '@/pages/leader/LeaderDashboard';
+import MeetingsPage from '@/pages/leader/MeetingsPage';
+import LeaderMeetingDetailPage from '@/pages/leader/MeetingDetailPage';
+import PromiseLedgerPage from '@/pages/leader/PromiseLedgerPage';
+import TeamSetupPage from '@/pages/leader/TeamSetupPage';
+import MemberDashboard from '@/pages/member/MemberDashboard';
+import MemberMeetingDetailPage from '@/pages/member/MeetingDetailPage';
+import SurveyPage from '@/pages/member/SurveyPage';
+import TeamJoinPage from '@/pages/member/TeamJoinPage';
+
+const router = createBrowserRouter([
+  { path: '/', element: <Navigate to="/leader/dashboard" replace /> },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/signup', element: <SignupPage /> },
+  { path: '/leader/team-setup', element: <TeamSetupPage /> },
+  { path: '/member/team-join', element: <TeamJoinPage /> },
+  { path: '/leader/dashboard', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/leader/meetings', element: <RequiresTeam><MeetingsPage /></RequiresTeam> },
+  { path: '/leader/meeting/:meetingId', element: <RequiresTeam><LeaderMeetingDetailPage /></RequiresTeam> },
+  { path: '/leader/promises', element: <RequiresTeam><PromiseLedgerPage /></RequiresTeam> },
+  { path: '/leader/reports', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/leader/9box', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/leader/overview', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/member/dashboard', element: <RequiresTeam><MemberDashboard /></RequiresTeam> },
+  { path: '/member/meeting/:meetingId', element: <RequiresTeam><MemberMeetingDetailPage /></RequiresTeam> },
+  { path: '/member/survey/:meetingId', element: <RequiresTeam><SurveyPage /></RequiresTeam> },
+  { path: '/settings', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/invite', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+]);
+
+export default router;
+```
+
+- [ ] **Step 2: `src/pages/auth/LoginPage.tsx` 수정**
+
+`handleSubmit`의 `navigate` 호출 부분 수정 (line 25 교체):
+
+변경 전:
+```tsx
+navigate(user.role === 'leader' ? '/leader/dashboard' : '/member/dashboard');
+```
+
+변경 후:
+```tsx
+if (user.teamId === '') {
+  navigate(user.role === 'leader' ? '/leader/team-setup' : '/member/team-join');
+} else {
+  navigate(user.role === 'leader' ? '/leader/dashboard' : '/member/dashboard');
+}
+```
+
+- [ ] **Step 3: `src/pages/auth/SignupPage.tsx` 수정**
+
+`handleSubmit` try 블록 내 `signup()` 호출 이후 3줄을 교체:
+
+변경 전 (lines 82-92):
+```tsx
+await signup({
+  name: form.name.trim(),
+  email: form.email.trim(),
+  password: form.password,
+  role: form.role,
+  jobTitle: form.jobTitle,
+});
+
+setMessage('가입이 성공하였습니다!');
+setMessageType('success');
+window.setTimeout(() => navigate('/login'), 1000);
+```
+
+변경 후:
+```tsx
+const authUser = await signup({
+  name: form.name.trim(),
+  email: form.email.trim(),
+  password: form.password,
+  role: form.role,
+  jobTitle: form.jobTitle,
+});
+
+if (authUser) {
+  navigate(authUser.role === 'leader' ? '/leader/team-setup' : '/member/team-join');
+} else {
+  setMessage('가입이 성공하였습니다!');
+  setMessageType('success');
+  window.setTimeout(() => navigate('/login'), 1000);
+}
+```
+
+- [ ] **Step 4: 타입 체크 + 린트**
+
+실행: `npm run type-check && npm run lint`  
+기대 결과: 에러 없음
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/router.tsx src/pages/auth/LoginPage.tsx src/pages/auth/SignupPage.tsx
+git commit -m "feat: wire RequiresTeam guard and team-setup redirects in auth pages"
+```

--- a/docs/superpowers/specs/2026-05-20-team-setup-design.md
+++ b/docs/superpowers/specs/2026-05-20-team-setup-design.md
@@ -124,7 +124,7 @@ joinTeam(inviteCode: string): Promise<JoinTeamResult>
 |------|-----------|
 | `src/app/router.tsx` | `RequiresTeam` 래퍼 적용, 2개 신규 라우트 추가 |
 | `src/pages/auth/LoginPage.tsx` | 로그인 후 `teamId === ''` 체크 → 팀 셋업 페이지 리다이렉트 |
-| `src/pages/auth/SignupPage.tsx` | 동일 (회원가입 응답도 `teamId: null`) |
+| `src/pages/auth/SignupPage.tsx` | 회원가입 성공 후 `authUser` 반환값을 사용해 `/login` 리다이렉트 대신 팀 셋업 페이지로 직접 이동. (`useSignup`은 이미 auth state를 설정하므로 재로그인 불필요) |
 
 ---
 

--- a/docs/superpowers/specs/2026-05-20-team-setup-design.md
+++ b/docs/superpowers/specs/2026-05-20-team-setup-design.md
@@ -1,0 +1,140 @@
+# Team Setup Flow — Design Spec
+
+**Date:** 2026-05-20  
+**Feature:** 팀 미소속 사용자를 위한 팀 생성/참여 플로우  
+**Branch:** jisu-team
+
+---
+
+## 배경
+
+신규 가입 사용자는 어떤 팀에도 속하지 않은 상태로 시작한다(`teamId === ''`). 이 상태에서 대시보드나 미팅 화면을 보여주는 것은 의미가 없으므로, 역할에 따라 팀 생성(리더) 또는 팀 참여(멤버) 화면을 먼저 보여줘야 한다.
+
+---
+
+## 적용 범위
+
+- 신규 회원가입 후 최초 진입
+- 기존 계정이지만 아직 팀에 소속되지 않은 경우
+- URL 직접 입력으로 보호된 라우트 접근 시도
+
+---
+
+## 아키텍처
+
+### 라우트 가드: `RequiresTeam`
+
+위치: `src/features/auth/RequiresTeam.tsx`
+
+보호된 모든 리더/멤버 라우트를 `<RequiresTeam>`으로 감싼다. 진입 시 아래 순서로 판단한다.
+
+```
+token 없음          → /login 리다이렉트
+user 없음 (로딩중)  → null 반환 (렌더링 대기)
+teamId === ''       → role에 따라 /leader/team-setup 또는 /member/team-join 리다이렉트
+teamId 있음         → 자식 컴포넌트 정상 렌더링
+```
+
+`/leader/team-setup`과 `/member/team-join`은 `RequiresTeam`으로 감싸지 않는다. 팀 없는 상태에서 접근해야 하는 페이지이기 때문이다.
+
+### 이중 보호
+
+1. **LoginPage / SignupPage**: 로그인·회원가입 직후 `teamId === ''`이면 팀 셋업 페이지로 리다이렉트
+2. **RequiresTeam**: URL 직접 입력 등 모든 보호 라우트 진입 시 재확인
+
+---
+
+## 새 라우트
+
+| 경로 | 컴포넌트 | 설명 |
+|------|----------|------|
+| `/leader/team-setup` | `TeamSetupPage` | 리더 팀 생성 |
+| `/member/team-join` | `TeamJoinPage` | 멤버 초대코드 입력 |
+
+---
+
+## 페이지 명세
+
+### TeamSetupPage (`/leader/team-setup`)
+
+- 팀 이름 입력 필드 (2~30자)
+- "팀 생성하기" 버튼
+- 생성 성공 시: **초대 코드 모달** 표시
+  - 초대 코드 텍스트 (클릭 시 클립보드 복사)
+  - "확인" 버튼 → `/leader/dashboard` 이동
+- 에러: 인라인 에러 메시지
+
+### TeamJoinPage (`/member/team-join`)
+
+- 초대 코드 입력 필드
+- "참여하기" 버튼
+- 참여 성공 시: **팀 참여 확인 모달** 표시
+  - "{teamName}에 참여했습니다."
+  - "확인" 버튼 → `/member/dashboard` 이동
+- 에러 처리:
+  - `TEAM_NOT_FOUND` → "유효하지 않은 초대 코드입니다"
+  - `ALREADY_IN_TEAM` → "이미 팀에 소속되어 있습니다"
+
+---
+
+## API 레이어
+
+### `src/api/teams.ts` (신규)
+
+```typescript
+createTeam(name: string): Promise<CreateTeamResult>
+// POST /api/v1/teams
+// 반환: { id, name, leaderId, leaderName, inviteCode }
+
+joinTeam(inviteCode: string): Promise<JoinTeamResult>
+// POST /api/v1/teams/join
+// 반환: { teamId, teamName }
+```
+
+---
+
+## Features 레이어
+
+### `src/features/team/useCreateTeam.ts` (신규)
+
+1. `createTeam(name)` 호출
+2. 성공 시 `fetchMe()` → `setAuth(freshUser, token)` 으로 authStore 갱신
+3. `inviteCode` 반환 (페이지에서 모달 표시에 사용)
+4. 상태: `isLoading`, `error`
+
+### `src/features/team/useJoinTeam.ts` (신규)
+
+1. `joinTeam(inviteCode)` 호출
+2. 성공 시 `fetchMe()` → `setAuth(freshUser, token)` 으로 authStore 갱신
+3. `teamName` 반환 (페이지에서 모달 표시에 사용)
+4. 상태: `isLoading`, `error`
+5. 에러 코드 → 한국어 메시지 변환 처리
+
+---
+
+## authStore 갱신 전략
+
+팀 생성/참여 성공 후 `GET /api/v1/users/me`를 호출해 최신 user 객체(teamId, teamName 포함)를 받아 `setAuth(freshUser, existingToken)`으로 갱신한다. 기존 authStore 인터페이스 변경 없음.
+
+---
+
+## 수정 대상 기존 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/app/router.tsx` | `RequiresTeam` 래퍼 적용, 2개 신규 라우트 추가 |
+| `src/pages/auth/LoginPage.tsx` | 로그인 후 `teamId === ''` 체크 → 팀 셋업 페이지 리다이렉트 |
+| `src/pages/auth/SignupPage.tsx` | 동일 (회원가입 응답도 `teamId: null`) |
+
+---
+
+## 신규 파일 목록
+
+| 파일 | 역할 |
+|------|------|
+| `src/features/auth/RequiresTeam.tsx` | 라우트 가드 컴포넌트 |
+| `src/pages/leader/TeamSetupPage.tsx` | 리더 팀 생성 페이지 |
+| `src/pages/member/TeamJoinPage.tsx` | 멤버 팀 참여 페이지 |
+| `src/features/team/useCreateTeam.ts` | 팀 생성 훅 |
+| `src/features/team/useJoinTeam.ts` | 팀 참여 훅 |
+| `src/api/teams.ts` | teams API 함수 |

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -26,13 +26,13 @@ export interface JoinTeamResult {
 }
 
 export async function createTeam(name: string): Promise<CreateTeamResult> {
-  const res = await apiClient.post<ApiResponse<CreateTeamApiResponse>>('/api/v1/teams', { name });
+  const res = await apiClient.post<ApiResponse<CreateTeamApiResponse>>('/v1/teams', { name });
   const d = res.data.data;
   return { id: String(d.id), name: d.name, inviteCode: d.inviteCode };
 }
 
 export async function joinTeam(inviteCode: string): Promise<JoinTeamResult> {
-  const res = await apiClient.post<ApiResponse<JoinTeamApiResponse>>('/api/v1/teams/join', { inviteCode });
+  const res = await apiClient.post<ApiResponse<JoinTeamApiResponse>>('/v1/teams/join', { inviteCode });
   const d = res.data.data;
   return { teamId: String(d.teamId), teamName: d.teamName };
 }

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,0 +1,38 @@
+import apiClient from './client';
+import type { ApiResponse } from './types';
+
+interface CreateTeamApiResponse {
+  id: string | number;
+  name: string;
+  leaderId: string | number;
+  leaderName: string;
+  inviteCode: string;
+}
+
+interface JoinTeamApiResponse {
+  teamId: string | number;
+  teamName: string;
+}
+
+export interface CreateTeamResult {
+  id: string;
+  name: string;
+  inviteCode: string;
+}
+
+export interface JoinTeamResult {
+  teamId: string;
+  teamName: string;
+}
+
+export async function createTeam(name: string): Promise<CreateTeamResult> {
+  const res = await apiClient.post<ApiResponse<CreateTeamApiResponse>>('/api/v1/teams', { name });
+  const d = res.data.data;
+  return { id: String(d.id), name: d.name, inviteCode: d.inviteCode };
+}
+
+export async function joinTeam(inviteCode: string): Promise<JoinTeamResult> {
+  const res = await apiClient.post<ApiResponse<JoinTeamApiResponse>>('/api/v1/teams/join', { inviteCode });
+  const d = res.data.data;
+  return { teamId: String(d.teamId), teamName: d.teamName };
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -2,13 +2,13 @@ import apiClient from './client';
 import type { User } from '@/types/user';
 
 interface MeApiData {
-  id: number;
+  id: string | number;
   email: string;
   name: string;
   role: 'LEADER' | 'MEMBER';
-  jobTitle: string;
-  teamId: number;
-  teamName: string;
+  jobTitle?: string | null;
+  teamId?: string | number | null;
+  teamName?: string | null;
 }
 
 interface MeApiResponse {
@@ -17,15 +17,15 @@ interface MeApiResponse {
 }
 
 export async function fetchMe(): Promise<User> {
-  const { data } = await apiClient.get<MeApiResponse>('/v1/users/me');
+  const { data } = await apiClient.get<MeApiResponse>('/api/v1/users/me');
   const u = data.data;
   return {
     id: String(u.id),
     email: u.email,
     name: u.name,
     role: u.role === 'LEADER' ? 'leader' : 'member',
-    jobTitle: u.jobTitle || undefined,
-    teamId: String(u.teamId),
-    teamName: u.teamName,
+    jobTitle: u.jobTitle ?? undefined,
+    teamId: u.teamId == null ? '' : String(u.teamId),
+    teamName: u.teamName ?? undefined,
   };
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,29 +1,34 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import RequiresTeam from '@/features/auth/RequiresTeam';
 import LoginPage from '@/pages/auth/LoginPage';
 import SignupPage from '@/pages/auth/SignupPage';
 import LeaderDashboard from '@/pages/leader/LeaderDashboard';
 import MeetingsPage from '@/pages/leader/MeetingsPage';
 import LeaderMeetingDetailPage from '@/pages/leader/MeetingDetailPage';
 import PromiseLedgerPage from '@/pages/leader/PromiseLedgerPage';
+import TeamSetupPage from '@/pages/leader/TeamSetupPage';
 import MemberDashboard from '@/pages/member/MemberDashboard';
 import MemberMeetingDetailPage from '@/pages/member/MeetingDetailPage';
 import SurveyPage from '@/pages/member/SurveyPage';
+import TeamJoinPage from '@/pages/member/TeamJoinPage';
 
 const router = createBrowserRouter([
   { path: '/', element: <Navigate to="/login" replace /> },
   { path: '/login', element: <LoginPage /> },
   { path: '/signup', element: <SignupPage /> },
-  { path: '/leader/dashboard', element: <LeaderDashboard /> },
-  { path: '/leader/meetings', element: <MeetingsPage /> },
-  { path: '/leader/meeting/:meetingId', element: <LeaderMeetingDetailPage /> },
-  { path: '/leader/promises', element: <PromiseLedgerPage /> },
-  { path: '/leader/reports', element: <LeaderDashboard /> },
-  { path: '/leader/overview', element: <LeaderDashboard /> },
-  { path: '/member/dashboard', element: <MemberDashboard /> },
-  { path: '/member/meeting/:meetingId', element: <MemberMeetingDetailPage /> },
-  { path: '/member/survey/:meetingId', element: <SurveyPage /> },
-  { path: '/settings', element: <LeaderDashboard /> },
-  { path: '/invite', element: <LeaderDashboard /> },
+  { path: '/leader/team-setup', element: <TeamSetupPage /> },
+  { path: '/member/team-join', element: <TeamJoinPage /> },
+  { path: '/leader/dashboard', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/leader/meetings', element: <RequiresTeam><MeetingsPage /></RequiresTeam> },
+  { path: '/leader/meeting/:meetingId', element: <RequiresTeam><LeaderMeetingDetailPage /></RequiresTeam> },
+  { path: '/leader/promises', element: <RequiresTeam><PromiseLedgerPage /></RequiresTeam> },
+  { path: '/leader/reports', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/leader/overview', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/member/dashboard', element: <RequiresTeam><MemberDashboard /></RequiresTeam> },
+  { path: '/member/meeting/:meetingId', element: <RequiresTeam><MemberMeetingDetailPage /></RequiresTeam> },
+  { path: '/member/survey/:meetingId', element: <RequiresTeam><SurveyPage /></RequiresTeam> },
+  { path: '/settings', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
+  { path: '/invite', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
 ]);
 
 export default router;

--- a/src/components/feedback/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react';
+
 export interface FeedbackCardProps {
   title: string;
-  content: string;
+  content: ReactNode;
   type?: 'error' | 'warning' | 'info' | 'success';
 }
 
@@ -29,7 +31,7 @@ export function FeedbackCard({ title, content, type = 'info' }: FeedbackCardProp
   return (
     <div className={`rounded-xl border p-4 ${styles.card}`}>
       <h4 className={`mb-1 text-sm font-medium ${styles.title}`}>{title}</h4>
-      <p className="whitespace-pre-line text-sm text-gray-600">{content}</p>
+      <div className="whitespace-pre-line text-sm text-gray-600">{content}</div>
     </div>
   );
 }

--- a/src/features/auth/RequiresTeam.tsx
+++ b/src/features/auth/RequiresTeam.tsx
@@ -1,0 +1,20 @@
+import { type ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function RequiresTeam({ children }: Props) {
+  const token = useAuthStore((s) => s.token);
+  const user = useAuthStore((s) => s.user);
+
+  if (!token) return <Navigate to="/login" replace />;
+  if (!user) return null;
+  if (user.teamId === '') {
+    return <Navigate to={user.role === 'leader' ? '/leader/team-setup' : '/member/team-join'} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/features/team/useCreateTeam.ts
+++ b/src/features/team/useCreateTeam.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { createTeam } from '@/api/teams';
+import { fetchMe } from '@/api/user';
+import { useAuthStore } from '@/stores/authStore';
+
+export function useCreateTeam() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const token = useAuthStore((s) => s.token);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const create = async (name: string): Promise<string> => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const result = await createTeam(name);
+      const freshUser = await fetchMe();
+      setAuth(freshUser, token ?? '');
+      return result.inviteCode;
+    } catch {
+      const message = '팀 생성에 실패했습니다.';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { create, isLoading, error };
+}

--- a/src/features/team/useJoinTeam.ts
+++ b/src/features/team/useJoinTeam.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { joinTeam } from '@/api/teams';
+import { fetchMe } from '@/api/user';
+import { useAuthStore } from '@/stores/authStore';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  TEAM_NOT_FOUND: '유효하지 않은 초대 코드입니다.',
+  ALREADY_IN_TEAM: '이미 팀에 소속되어 있습니다.',
+};
+
+export function useJoinTeam() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const token = useAuthStore((s) => s.token);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const join = async (inviteCode: string): Promise<string> => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const result = await joinTeam(inviteCode);
+      const freshUser = await fetchMe();
+      setAuth(freshUser, token ?? '');
+      return result.teamName;
+    } catch (err) {
+      const code =
+        err && typeof err === 'object' && 'response' in err
+          ? (err.response as { data?: { code?: string } })?.data?.code
+          : undefined;
+      const message = (code && ERROR_MESSAGES[code]) ?? '팀 참여에 실패했습니다.';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { join, isLoading, error };
+}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -22,7 +22,11 @@ export default function LoginPage() {
 
     try {
       const user = await login({ email, password });
-      navigate(user.role === 'leader' ? '/leader/dashboard' : '/member/dashboard');
+      if (user.teamId === '') {
+        navigate(user.role === 'leader' ? '/leader/team-setup' : '/member/team-join');
+      } else {
+        navigate(user.role === 'leader' ? '/leader/dashboard' : '/member/dashboard');
+      }
     } catch {
       setErrorMessage('이메일 또는 비밀번호가 올바르지 않습니다');
     }

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -84,7 +84,7 @@ export default function SignupPage() {
         throw new Error('Role is required');
       }
 
-      await signup({
+      const authUser = await signup({
         name: form.name.trim(),
         email: form.email.trim(),
         password: form.password,
@@ -92,9 +92,13 @@ export default function SignupPage() {
         jobTitle: form.jobTitle,
       });
 
-      setMessage('가입이 성공하였습니다!');
-      setMessageType('success');
-      window.setTimeout(() => navigate('/login'), 1000);
+      if (authUser) {
+        navigate(authUser.role === 'leader' ? '/leader/team-setup' : '/member/team-join');
+      } else {
+        setMessage('가입이 성공하였습니다!');
+        setMessageType('success');
+        window.setTimeout(() => navigate('/login'), 1000);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : '회원 가입에 실패했습니다.';
       setMessage(message);

--- a/src/pages/leader/MeetingsPage.tsx
+++ b/src/pages/leader/MeetingsPage.tsx
@@ -6,10 +6,12 @@ import type { MeetingData } from "@/types/meeting";
 import { ROUTES } from "@/constants/routes";
 
 const statusMap: Record<MeetingData["status"], { label: string; badge: string }> = {
-  pending: { label: "대기 중", badge: "bg-yellow-100 text-yellow-700" },
-  recording: { label: "녹음 중", badge: "bg-blue-100 text-blue-700" },
-  analyzing: { label: "분석 중", badge: "bg-purple-100 text-purple-700" },
-  completed: { label: "완료", badge: "bg-emerald-100 text-emerald-700" },
+  pending:   { label: "대기 중",  badge: "bg-yellow-100 text-yellow-700" },
+  recording: { label: "녹음 중",  badge: "bg-blue-100 text-blue-700" },
+  uploading: { label: "업로드 중", badge: "bg-orange-100 text-orange-700" },
+  analyzing: { label: "분석 중",  badge: "bg-purple-100 text-purple-700" },
+  completed: { label: "완료",     badge: "bg-emerald-100 text-emerald-700" },
+  error:     { label: "오류",     badge: "bg-red-100 text-red-700" },
 };
 
 const actionItems = [

--- a/src/pages/leader/TeamSetupPage.tsx
+++ b/src/pages/leader/TeamSetupPage.tsx
@@ -1,0 +1,85 @@
+import { type FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Modal from '@/components/ui/Modal';
+import { useCreateTeam } from '@/features/team/useCreateTeam';
+
+export default function TeamSetupPage() {
+  const navigate = useNavigate();
+  const { create, isLoading, error } = useCreateTeam();
+  const [teamName, setTeamName] = useState('');
+  const [inviteCode, setInviteCode] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = teamName.trim();
+    if (trimmed.length < 2 || trimmed.length > 30) return;
+    try {
+      const code = await create(trimmed);
+      setInviteCode(code);
+      setModalOpen(true);
+    } catch {
+      // error is set in hook
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(inviteCode).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const handleConfirm = () => {
+    setModalOpen(false);
+    navigate('/leader/dashboard');
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6">
+      <section className="w-full max-w-sm">
+        <h1 className="mb-2 text-center text-3xl font-bold text-black">팀 만들기</h1>
+        <p className="mb-8 text-center text-sm text-gray-500">팀 이름을 입력하고 팀을 생성하세요.</p>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">팀 이름</span>
+            <Input
+              type="text"
+              value={teamName}
+              onChange={(e) => setTeamName(e.target.value)}
+              placeholder="팀 이름을 입력하세요 (2~30자)"
+              minLength={2}
+              maxLength={30}
+            />
+          </label>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <Button type="submit" className="w-full" disabled={isLoading || teamName.trim().length < 2}>
+            {isLoading ? '생성 중...' : '팀 생성하기'}
+          </Button>
+        </form>
+
+        <Modal open={modalOpen} onClose={() => {}}>
+          <h2 className="mb-4 text-lg font-bold text-black">팀이 생성되었습니다!</h2>
+          <p className="mb-2 text-sm text-gray-600">아래 초대 코드를 팀원에게 공유하세요.</p>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="mb-4 w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-center font-mono text-lg font-semibold tracking-widest text-black hover:bg-gray-100"
+          >
+            {inviteCode}
+          </button>
+          {copied && <p className="mb-2 text-center text-xs text-green-600">클립보드에 복사되었습니다.</p>}
+          <Button className="w-full" onClick={handleConfirm}>
+            확인
+          </Button>
+        </Modal>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/member/MeetingDetailPage.tsx
+++ b/src/pages/member/MeetingDetailPage.tsx
@@ -44,7 +44,7 @@ export default function MemberMeetingDetailPage() {
       <PageLayout>
         <div className="flex flex-col">
           <MeetingHeader meeting={meeting} />
-          <AnalysisLoading role="member" />
+          <AnalysisLoading role="member" meetingId={meetingId ?? ""} />
         </div>
       </PageLayout>
     );

--- a/src/pages/member/TeamJoinPage.tsx
+++ b/src/pages/member/TeamJoinPage.tsx
@@ -1,0 +1,66 @@
+import { type FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Modal from '@/components/ui/Modal';
+import { useJoinTeam } from '@/features/team/useJoinTeam';
+
+export default function TeamJoinPage() {
+  const navigate = useNavigate();
+  const { join, isLoading, error } = useJoinTeam();
+  const [inviteCode, setInviteCode] = useState('');
+  const [joinedTeamName, setJoinedTeamName] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = inviteCode.trim();
+    if (!trimmed) return;
+    try {
+      const teamName = await join(trimmed);
+      setJoinedTeamName(teamName);
+      setModalOpen(true);
+    } catch {
+      // error is set in hook
+    }
+  };
+
+  const handleConfirm = () => {
+    setModalOpen(false);
+    navigate('/member/dashboard');
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6">
+      <section className="w-full max-w-sm">
+        <h1 className="mb-2 text-center text-3xl font-bold text-black">팀 참여하기</h1>
+        <p className="mb-8 text-center text-sm text-gray-500">리더에게 받은 초대 코드를 입력하세요.</p>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-800">초대 코드</span>
+            <Input
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              placeholder="초대 코드를 입력하세요"
+            />
+          </label>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <Button type="submit" className="w-full" disabled={isLoading || !inviteCode.trim()}>
+            {isLoading ? '참여 중...' : '참여하기'}
+          </Button>
+        </form>
+
+        <Modal open={modalOpen} onClose={() => {}}>
+          <h2 className="mb-4 text-lg font-bold text-black">{joinedTeamName}에 참여했습니다.</h2>
+          <Button className="w-full" onClick={handleConfirm}>
+            확인
+          </Button>
+        </Modal>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- 팀 설정 플로우 구현: 리더용 팀 생성 페이지(`TeamSetupPage`), 멤버용 팀 참여 페이지(`TeamJoinPage`) 추가
- `RequiresTeam` 라우트 가드 추가 — 팀이 없는 사용자를 팀 설정 페이지로 리다이렉트
- 로그인/회원가입 후 팀 유무에 따른 라우팅 연결
- TypeScript 빌드 에러 3건 수정

## Changes

- `src/features/auth/RequiresTeam.tsx` — 팀 가드 컴포넌트
- `src/features/team/useCreateTeam.ts`, `useJoinTeam.ts` — 팀 생성/참여 훅
- `src/api/teams.ts` — 팀 API 함수
- `src/pages/leader/TeamSetupPage.tsx`, `src/pages/member/TeamJoinPage.tsx` — 신규 페이지
- `src/components/feedback/FeedbackCard.tsx` — content 타입 `string` → `ReactNode`
- `src/pages/leader/MeetingsPage.tsx` — statusMap에 `uploading`, `error` 추가
- `src/pages/member/MeetingDetailPage.tsx` — `AnalysisLoading`에 `meetingId` prop 전달

## Test plan

- [ ] 팀 없는 계정으로 로그인 시 팀 설정 페이지로 리다이렉트 확인
- [ ] 리더: TeamSetupPage에서 팀 생성 후 대시보드 이동 확인
- [ ] 멤버: TeamJoinPage에서 팀 참여 후 대시보드 이동 확인
- [ ] `npm run build` 에러 없이 통과 확인
