### PR TITLE
#FEAT: 멤버 미팅 후 리포트 페이지 추가 및 서베이 백엔드 연결

### DIFF
--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -1,9 +1,38 @@
 import apiClient from './client';
 import type { ApiResponse } from './types';
 import type { MeetingDetail, MeetingListItem } from '@/types/meeting';
+import type { MemberReportData } from '@/types/memberReport';
+
+export interface SubmitSurveyPayload {
+  meetingId: number;
+  scores: {
+    issues: string[];
+    energyLevel: number;
+    desiredRoles: string[];
+  };
+}
+
+export interface SurveyData {
+  id: number;
+  meetingId: number;
+  memberId: number;
+  scores: {
+    issues?: string[];
+    energyLevel?: number;
+    desiredRoles?: string[];
+    [key: string]: unknown;
+  };
+}
 
 export async function fetchMeetingDetail(meetingId: string): Promise<MeetingDetail> {
   const res = await apiClient.get<ApiResponse<MeetingDetail>>(`/v1/meetings/${meetingId}`);
+  return res.data.data;
+}
+
+export async function fetchMemberReport(meetingId: string): Promise<MemberReportData> {
+  const res = await apiClient.get<ApiResponse<MemberReportData>>(
+    `/v1/meetings/${meetingId}/member-report`,
+  );
   return res.data.data;
 }
 
@@ -20,5 +49,14 @@ export async function fetchMeetings(teamId: string): Promise<MeetingListItem[]> 
   const res = await apiClient.get<ApiResponse<MeetingListItem[]>>(`/v1/meetings`, {
     params: { teamId },
   });
+  return res.data.data;
+}
+
+export async function submitSurvey(payload: SubmitSurveyPayload): Promise<void> {
+  await apiClient.post<ApiResponse<void>>('/v1/surveys', payload);
+}
+
+export async function fetchSurvey(meetingId: string): Promise<SurveyData> {
+  const res = await apiClient.get<ApiResponse<SurveyData>>(`/v1/surveys/${meetingId}`);
   return res.data.data;
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -9,6 +9,7 @@ import PromiseLedgerPage from '@/pages/leader/PromiseLedgerPage';
 import TeamSetupPage from '@/pages/leader/TeamSetupPage';
 import MemberDashboard from '@/pages/member/MemberDashboard';
 import MemberMeetingDetailPage from '@/pages/member/MeetingDetailPage';
+import MemberReportPage from '@/pages/member/MemberReportPage';
 import SurveyPage from '@/pages/member/SurveyPage';
 import TeamJoinPage from '@/pages/member/TeamJoinPage';
 
@@ -26,6 +27,7 @@ const router = createBrowserRouter([
   { path: '/leader/overview', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
   { path: '/member/dashboard', element: <RequiresTeam><MemberDashboard /></RequiresTeam> },
   { path: '/member/meeting/:meetingId', element: <RequiresTeam><MemberMeetingDetailPage /></RequiresTeam> },
+  { path: '/member/meeting/:meetingId/report', element: <RequiresTeam><MemberReportPage /></RequiresTeam> },
   { path: '/member/survey/:meetingId', element: <RequiresTeam><SurveyPage /></RequiresTeam> },
   { path: '/settings', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
   { path: '/invite', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },

--- a/src/components/survey/SurveyForm.tsx
+++ b/src/components/survey/SurveyForm.tsx
@@ -1,16 +1,45 @@
+import axios from 'axios';
 import { useMemo, useState } from 'react';
+import { submitSurvey } from '@/api/meetings';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
 
-const issueOptions = ['업무 블로커', '커리어 성장', '팀 협업', '리소스 요청', '기타'];
-const energyOptions = [
-  { value: 1, icon: '😫', label: '많이 지침' },
-  { value: 2, icon: '😳', label: '조금 힘듦' },
-  { value: 3, icon: '😊', label: '보통' },
-  { value: 4, icon: '😄', label: '좋음' },
-  { value: 5, icon: '🔥', label: '최고!' },
+const issueOptions = [
+  { value: '업무 블로커', label: '업무 진행을 막는 이슈가 있어요' },
+  { value: '리소스 요청', label: '인력/도구 등 리소스가 부족해요' },
+  { value: '커리어 성장', label: '커리어 방향에 대해 이야기하고 싶어요' },
+  { value: '팀 분위기', label: '팀 분위기/협업에 대해 이야기하고 싶어요' },
+  { value: '프로세스 개선', label: '프로세스 개선이 필요해요' },
+  { value: '인정/피드백', label: '인정이나 피드백을 받고 싶어요' },
+  { value: '기타', label: '기타 주제' },
 ];
-const desiredRoleOptions = ['그냥 들어주기', '방향성 코칭', '의사결정 도움', '리소스 확보'];
+
+const energyOptions = [
+  { value: 1, icon: '😫', label: '많이 지쳤어요' },
+  { value: 2, icon: '😳', label: '조금 힘들어요' },
+  { value: 3, icon: '😊', label: '보통이에요' },
+  { value: 4, icon: '😄', label: '좋아요' },
+  { value: 5, icon: '🔥', label: '최고예요' },
+];
+
+const desiredRoleOptions = [
+  { value: '방향성 코칭', label: '방향성을 잡아주세요' },
+  { value: '의사결정 도움', label: '의사결정을 도와주세요' },
+  { value: '리소스 지원', label: '리소스를 확보해 주세요' },
+  { value: '경청/공감', label: '들어주시고 공감해 주세요' },
+  { value: '기술적 멘토링', label: '기술적 조언이 필요해요' },
+];
+
+const submitErrorMessages: Record<string, string> = {
+  SURVEY_ALREADY_SUBMITTED: '이미 서베이를 제출한 미팅입니다.',
+  FORBIDDEN: '본인이 참여한 미팅에만 서베이를 제출할 수 있습니다.',
+  MEETING_NOT_FOUND: '존재하지 않는 미팅입니다.',
+};
+
+interface ApiErrorBody {
+  code?: string;
+  message?: string;
+}
 
 export interface SurveyFormProps {
   leaderName: string;
@@ -23,8 +52,11 @@ export default function SurveyForm({ leaderName, scheduledAt, meetingId }: Surve
   const [energyLevel, setEnergyLevel] = useState<number | null>(3);
   const [desiredRoles, setDesiredRoles] = useState<string[]>([]);
   const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const canSubmit = selectedIssues.length > 0 && energyLevel !== null && desiredRoles.length > 0;
+  const canSubmit =
+    meetingId > 0 && selectedIssues.length > 0 && energyLevel !== null && desiredRoles.length > 0;
 
   const selectedEnergyLabel = useMemo(
     () => energyOptions.find((option) => option.value === energyLevel)?.label ?? '',
@@ -44,14 +76,40 @@ export default function SurveyForm({ leaderName, scheduledAt, meetingId }: Surve
 
   const toggleValue = (value: string, values: string[], setValues: (next: string[]) => void) => {
     setMessage('');
+    setError('');
     setValues(values.includes(value) ? values.filter((item) => item !== value) : [...values, value]);
   };
 
-  const handleSubmit = () => {
-    if (!canSubmit) return;
-    const payload = { meetingId, issues: selectedIssues, energyLevel, desiredRoles };
-    console.log('survey payload', payload);
-    setMessage('설문이 제출되었습니다.');
+  const getSubmitErrorMessage = (err: unknown) => {
+    if (axios.isAxiosError<ApiErrorBody>(err)) {
+      const code = err.response?.data?.code;
+      return (code && submitErrorMessages[code]) ?? err.response?.data?.message;
+    }
+    return undefined;
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit || energyLevel === null || isSubmitting) return;
+
+    setIsSubmitting(true);
+    setMessage('');
+    setError('');
+
+    try {
+      await submitSurvey({
+        meetingId,
+        scores: {
+          issues: selectedIssues,
+          energyLevel,
+          desiredRoles,
+        },
+      });
+      setMessage('서베이가 제출되었습니다.');
+    } catch (err) {
+      setError(getSubmitErrorMessage(err) ?? '서베이 제출에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -60,9 +118,9 @@ export default function SurveyForm({ leaderName, scheduledAt, meetingId }: Surve
         {leaderName}님과 1on1이 예정되어 있습니다.
       </p>
       <h1 className="mt-5 text-center text-2xl font-bold leading-snug text-gray-900">
-        사전 설문 조사를 진행해 주세요!
+        사전 설문 조사를 진행해 주세요
       </h1>
-      <p className="mt-4 text-center text-base tracking-wide text-slate-400">{scheduledDate}</p>
+      <p className="mt-4 text-center text-base tracking-wide text-slate-400">{scheduledDate}요일</p>
 
       <Card className="mt-10 w-full rounded-[20px] border-gray-200 px-9 py-9 shadow-sm">
         <div className="space-y-9">
@@ -70,19 +128,19 @@ export default function SurveyForm({ leaderName, scheduledAt, meetingId }: Surve
             <h2 className="text-lg font-extrabold text-gray-900">Q1. 오늘 꼭 다루고 싶은 이슈는?</h2>
             <div className="mt-5 flex flex-wrap gap-3">
               {issueOptions.map((issue) => {
-                const isSelected = selectedIssues.includes(issue);
+                const isSelected = selectedIssues.includes(issue.value);
                 return (
                   <button
-                    key={issue}
+                    key={issue.value}
                     type="button"
-                    onClick={() => toggleValue(issue, selectedIssues, setSelectedIssues)}
+                    onClick={() => toggleValue(issue.value, selectedIssues, setSelectedIssues)}
                     className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
                       isSelected
                         ? 'border-violet-500 bg-violet-50 text-violet-700'
                         : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
                     }`}
                   >
-                    {issue}
+                    {issue.label}
                   </button>
                 );
               })}
@@ -98,14 +156,18 @@ export default function SurveyForm({ leaderName, scheduledAt, meetingId }: Surve
                   <button
                     key={energy.value}
                     type="button"
-                    onClick={() => { setEnergyLevel(energy.value); setMessage(''); }}
+                    onClick={() => {
+                      setEnergyLevel(energy.value);
+                      setMessage('');
+                      setError('');
+                    }}
                     className={`flex aspect-square min-h-[88px] flex-col items-center justify-center rounded-[18px] border text-center transition-colors ${
                       isSelected
                         ? 'border-violet-500 bg-violet-50 text-violet-700 shadow-[0_0_0_1px_rgba(139,92,246,0.9)]'
                         : 'border-slate-200 bg-white text-slate-400 hover:border-slate-300'
                     }`}
                   >
-                    <span className="text-3xl leading-none">{energy.icon}</span>
+                    <span className="text-2xl font-extrabold leading-none">{energy.icon}</span>
                     <span className="mt-3 text-[11px] font-bold">{energy.label}</span>
                   </button>
                 );
@@ -117,19 +179,19 @@ export default function SurveyForm({ leaderName, scheduledAt, meetingId }: Surve
             <h2 className="text-lg font-extrabold text-gray-900">Q3. 이번 미팅에서 리더에게 바라는 역할은?</h2>
             <div className="mt-5 flex flex-wrap gap-3">
               {desiredRoleOptions.map((role) => {
-                const isSelected = desiredRoles.includes(role);
+                const isSelected = desiredRoles.includes(role.value);
                 return (
                   <button
-                    key={role}
+                    key={role.value}
                     type="button"
-                    onClick={() => toggleValue(role, desiredRoles, setDesiredRoles)}
+                    onClick={() => toggleValue(role.value, desiredRoles, setDesiredRoles)}
                     className={`rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors ${
                       isSelected
                         ? 'border-violet-500 bg-violet-50 text-violet-700'
                         : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
                     }`}
                   >
-                    {role}
+                    {role.label}
                   </button>
                 );
               })}
@@ -140,19 +202,18 @@ export default function SurveyForm({ leaderName, scheduledAt, meetingId }: Surve
             <Button
               type="button"
               onClick={handleSubmit}
-              disabled={!canSubmit}
+              disabled={!canSubmit || isSubmitting}
               className={`h-14 w-full text-base ${
                 canSubmit
                   ? 'bg-gray-900 text-white hover:bg-gray-700'
                   : 'bg-slate-100 text-slate-400 hover:bg-slate-100 disabled:opacity-100'
               }`}
             >
-              제출하기
+              {isSubmitting ? '제출 중...' : '제출하기'}
             </Button>
             {message && <p className="mt-4 text-center text-sm font-medium text-green-600">{message}</p>}
-            <p className="mt-9 text-center text-sm text-slate-400">
-              소요시간 약 30초 <span aria-hidden="true">⏱️</span>
-            </p>
+            {error && <p className="mt-4 text-center text-sm font-medium text-red-600">{error}</p>}
+            <p className="mt-9 text-center text-sm text-slate-400">소요시간 약 30초</p>
             <span className="sr-only">현재 에너지 레벨: {selectedEnergyLabel}</span>
           </div>
         </div>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -6,5 +6,6 @@ export const ROUTES = {
   LEADER_PROMISES: '/leader/promises',
   MEMBER_DASHBOARD: '/member/dashboard',
   MEMBER_MEETING: (id: string) => `/member/meeting/${id}`,
+  MEMBER_REPORT: (id: string) => `/member/meeting/${id}/report`,
   MEMBER_SURVEY: (id: string) => `/member/survey/${id}`,
 } as const;

--- a/src/data/mockMemberReport.ts
+++ b/src/data/mockMemberReport.ts
@@ -1,0 +1,59 @@
+import type { MemberReportData } from '@/types/memberReport';
+
+export const MOCK_MEMBER_REPORT: MemberReportData = {
+  meetingId: 10,
+  round: 12,
+  leaderName: '이준혁 팀장',
+  meetingDate: '2026-05-08',
+  durationSec: 2400,
+  confirmedAchievements: [
+    {
+      careerEventId: 15,
+      type: 'ACHIEVEMENT',
+      title: '스프린트 3 FE 리드 완주',
+      description: 'API 지연 상황에서 목 서버를 직접 구축해 팀 전체 개발을 무중단으로 유지했습니다.',
+      impactMetric: '출시 지연 0일',
+      leaderQuote: '위기 상황에서의 문제해결 능력과 팀 전체를 이끄는 자세가 탁월했습니다.',
+      leaderName: '이준혁 팀장',
+    },
+    {
+      careerEventId: 16,
+      type: 'PROPOSAL_ADOPTED',
+      title: '공통 컴포넌트 라이브러리 기여',
+      description: 'DatePicker 공통화로 3개 팀 총 60시간 절감.',
+      impactMetric: '공수 -60h',
+      leaderQuote: '혼자 해결하지 않고 팀 전체를 끌어올리는 기여였습니다.',
+      leaderName: '이준혁 팀장',
+    },
+  ],
+  leaderPromises: [
+    {
+      promiseId: 4,
+      content: 'AWS 프로덕션 접근 권한 부여',
+      category: 'RESOURCE',
+      dueDate: '2026-05-15',
+      status: 'PENDING',
+    },
+    {
+      promiseId: 5,
+      content: 'QA 충원 안건 전사 회의 상정',
+      category: 'TEAM_BUILDING',
+      dueDate: '2026-05-12',
+      status: 'PENDING',
+    },
+    {
+      promiseId: 6,
+      content: 'MSA 전환 성과 5월 올핸즈 발표',
+      category: 'RECOGNITION',
+      dueDate: '2026-05-20',
+      status: 'PENDING',
+    },
+    {
+      promiseId: 7,
+      content: 'FE 코드 리뷰 SLA 기준 문서화',
+      category: 'PROCESS',
+      dueDate: '2026-04-30',
+      status: 'DONE',
+    },
+  ],
+};

--- a/src/features/meeting/useSurveyCompletion.ts
+++ b/src/features/meeting/useSurveyCompletion.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import { useEffect, useRef, useState } from 'react';
+import { fetchSurvey } from '@/api/meetings';
+
+const POLL_INTERVAL_MS = 3000;
+
+interface ApiErrorBody {
+  code?: string;
+}
+
+function isSurveyMissing(err: unknown) {
+  if (!axios.isAxiosError<ApiErrorBody>(err)) return false;
+  return err.response?.status === 404 || err.response?.data?.code === 'SURVEY_NOT_FOUND';
+}
+
+export function useSurveyCompletion(meetingId: string | undefined, active: boolean) {
+  const [completed, setCompleted] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!meetingId || !active) {
+      setChecking(false);
+      return;
+    }
+
+    let cancelled = false;
+    setChecking(true);
+    setCompleted(false);
+
+    const clearPoll = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    const check = async () => {
+      try {
+        await fetchSurvey(meetingId);
+        if (cancelled) return;
+        setCompleted(true);
+        setChecking(false);
+        clearPoll();
+      } catch (err) {
+        if (cancelled) return;
+        if (isSurveyMissing(err)) {
+          setCompleted(false);
+          setChecking(false);
+          return;
+        }
+        setChecking(false);
+      }
+    };
+
+    check();
+    intervalRef.current = setInterval(check, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearPoll();
+    };
+  }, [meetingId, active]);
+
+  return { completed, checking };
+}

--- a/src/features/member/useMemberReport.ts
+++ b/src/features/member/useMemberReport.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { fetchMemberReport } from '@/api/meetings';
+import { MOCK_MEMBER_REPORT } from '@/data/mockMemberReport';
+import type { MemberReportData } from '@/types/memberReport';
+
+export function useMemberReport(meetingId: string | undefined) {
+  const [data, setData] = useState<MemberReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!meetingId) {
+      setLoading(false);
+      setError('미팅 정보를 찾을 수 없습니다.');
+      return;
+    }
+
+    if (import.meta.env.VITE_USE_MOCK?.trim() === 'true') {
+      const timer = setTimeout(() => {
+        setData({
+          ...MOCK_MEMBER_REPORT,
+          meetingId: Number(meetingId) || MOCK_MEMBER_REPORT.meetingId,
+        });
+        setLoading(false);
+      }, 250);
+
+      return () => clearTimeout(timer);
+    }
+
+    setLoading(true);
+    setError(null);
+    fetchMemberReport(meetingId)
+      .then(setData)
+      .catch(() => setError('멤버 리포트를 불러오지 못했습니다.'))
+      .finally(() => setLoading(false));
+  }, [meetingId]);
+
+  return { data, loading, error };
+}

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -4,6 +4,7 @@ import PageLayout from "@/components/layout/PageLayout";
 import { useRecorder } from "@/features/meeting/useRecorder";
 import { useUploadRecording } from "@/features/meeting/useUploadRecording";
 import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
+import { useSurveyCompletion } from "@/features/meeting/useSurveyCompletion";
 import StartMeetingModal from "@/components/ui/StartMeetingModal";
 import EndMeetingModal from "@/components/ui/EndMeetingModal";
 import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
@@ -23,6 +24,11 @@ export default function MeetingDetailPage() {
   const [localStatus, setLocalStatus] = useState<LocalStatus>("pending");
   const [uploadError, setUploadError] = useState<string | null>(null);
   const pendingUploadRef = useRef<{ blob: Blob; durationSec: number } | null>(null);
+  // 서베이 결과 적용 임시 테스트용 
+  const { completed: surveyCompleted } = useSurveyCompletion(
+    meetingId,
+    !loading && !error && localStatus === "pending",
+  );
 
   useEffect(() => {
     if (meeting?.status === "ANALYZING" || meeting?.status === "RECORDING") {
@@ -153,7 +159,7 @@ export default function MeetingDetailPage() {
             <div className="flex-1 flex flex-col items-center justify-center gap-3 px-8 pb-32">
               {(() => {
                 const skipCheck = import.meta.env.VITE_SKIP_SURVEY_CHECK === 'true';
-                const surveyDone = skipCheck || meeting.surveyCompleted === true;
+                const surveyDone = skipCheck || meeting.surveyCompleted === true || surveyCompleted;
                 return (
                   <>
                     <div className={`text-center text-sm ${surveyDone ? 'text-[#5F74FA]' : 'text-gray-400'}`}>

--- a/src/pages/member/MeetingDetailPage.tsx
+++ b/src/pages/member/MeetingDetailPage.tsx
@@ -4,6 +4,7 @@ import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
 import SurveyForm from "@/components/survey/SurveyForm";
 import AnalysisLoading from "@/components/loading/AnalysisLoading";
 import type { MeetingDetail } from "@/types/meeting";
+import MemberReportPage from "@/pages/member/MemberReportPage";
 
 export default function MemberMeetingDetailPage() {
   const { meetingId } = useParams<{ meetingId: string }>();
@@ -48,6 +49,10 @@ export default function MemberMeetingDetailPage() {
         </div>
       </PageLayout>
     );
+  }
+
+  if (meeting.status === "COMPLETED") {
+    return <MemberReportPage />;
   }
 
   return (

--- a/src/pages/member/MemberReportPage.tsx
+++ b/src/pages/member/MemberReportPage.tsx
@@ -1,0 +1,216 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import PageLayout from '@/components/layout/PageLayout';
+import Card from '@/components/ui/Card';
+import { useMemberReport } from '@/features/member/useMemberReport';
+import type {
+  ConfirmedAchievement,
+  LeaderPromise,
+  MemberAchievementType,
+  MemberPromiseCategory,
+  MemberPromiseStatus,
+} from '@/types/memberReport';
+
+const achievementStyles: Record<MemberAchievementType, { keyword: string; card: string; text: string }> = {
+  ACHIEVEMENT: {
+    keyword: '성취',
+    card: 'border-gray-200 bg-gray-50',
+    text: 'text-emerald-700',
+  },
+  PROPOSAL_ADOPTED: {
+    keyword: '기여',
+    card: 'border-gray-200 bg-gray-50',
+    text: 'text-blue-700',
+  },
+};
+
+const categoryTextStyles: Record<MemberPromiseCategory, string> = {
+  RESOURCE: 'text-blue-700',
+  TEAM_BUILDING: 'text-violet-700',
+  RECOGNITION: 'text-amber-700',
+  PROCESS: 'text-teal-700',
+};
+
+const categoryLabels: Record<MemberPromiseCategory, string> = {
+  RESOURCE: '리소스',
+  TEAM_BUILDING: '팀빌딩',
+  RECOGNITION: '인정',
+  PROCESS: '프로세스',
+};
+
+const statusLabels: Record<MemberPromiseStatus, string> = {
+  PENDING: '진행 중',
+  DONE: '완료',
+};
+
+function formatDuration(durationSec: number) {
+  return `${Math.floor(durationSec / 60)}분`;
+}
+
+function formatDate(date: string) {
+  return new Date(`${date}T00:00:00`).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function sortPromises(promises: LeaderPromise[]) {
+  return [...promises].sort((a, b) => {
+    if (a.status === 'DONE' && b.status !== 'DONE') return 1;
+    if (a.status !== 'DONE' && b.status === 'DONE') return -1;
+    return a.dueDate.localeCompare(b.dueDate);
+  });
+}
+
+function AchievementCard({ achievement }: { achievement: ConfirmedAchievement }) {
+  const style = achievementStyles[achievement.type];
+
+  return (
+    <article className={`rounded-xl border p-4 ${style.card}`}>
+      <div className="flex flex-col gap-2.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`text-sm font-bold ${style.text}`}>#{style.keyword}</span>
+          <h3 className="text-base font-bold leading-6 text-gray-950">{achievement.title}</h3>
+        </div>
+
+        <p className="text-sm leading-6 text-gray-800">
+          {achievement.description}{' '}
+          <span className={`ml-1 text-xs font-semibold ${style.text}`}>
+            {achievement.impactMetric}
+          </span>
+        </p>
+
+        <p className="mt-1 border-l-2 border-gray-300 pl-3 text-sm leading-6 text-gray-600">
+          "{achievement.leaderQuote}" - {achievement.leaderName}
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function PromiseItem({ promise }: { promise: LeaderPromise }) {
+  const isDone = promise.status === 'DONE';
+  const categoryTone = categoryTextStyles[promise.category];
+  const cardTone = isDone ? 'border-gray-200 bg-gray-100' : 'border-gray-200 bg-white';
+
+  return (
+    <li className={`rounded-xl border p-4 ${cardTone}`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2 text-xs font-semibold">
+            <span className={categoryTone}>#{categoryLabels[promise.category]}</span>
+            <span className={isDone ? 'text-gray-500' : categoryTone}>
+              마감 {formatDate(promise.dueDate)}
+            </span>
+          </div>
+
+          <p
+            className={`mt-2 text-sm font-semibold leading-6 ${
+              isDone
+                ? 'text-gray-500 line-through decoration-gray-500 decoration-2'
+                : 'text-gray-950'
+            }`}
+          >
+            {promise.content}
+          </p>
+        </div>
+
+        <span
+          className={`shrink-0 text-xs font-bold ${
+            isDone ? 'text-gray-500' : 'text-emerald-700'
+          }`}
+        >
+          {statusLabels[promise.status]}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+export default function MemberReportPage() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+  const { data: report, loading, error } = useMemberReport(meetingId);
+  const sortedPromises = useMemo(
+    () => sortPromises(report?.leaderPromises ?? []),
+    [report?.leaderPromises],
+  );
+
+  if (loading) {
+    return (
+      <PageLayout>
+        <div className="mx-auto max-w-[1120px] p-6">
+          <Card className="p-6">
+            <p className="text-sm text-gray-500">멤버 리포트를 불러오는 중입니다.</p>
+          </Card>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <PageLayout>
+        <div className="mx-auto max-w-[1120px] p-6">
+          <Card className="p-6">
+            <p className="text-sm text-gray-500">{error ?? '멤버 리포트를 찾을 수 없습니다.'}</p>
+          </Card>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout>
+      <div className="mx-auto max-w-[1120px] bg-[#F7F8FA] p-6">
+        <header className="mb-6 flex flex-col gap-4 rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-gray-500">{formatDate(report.meetingDate)}</p>
+              <h1 className="mt-2 text-2xl font-bold text-gray-950">1on1 분석 리포트</h1>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs font-medium text-gray-500">
+              <span className="rounded-full border border-gray-100 bg-gray-50 px-3 py-1">
+                # {report.round}회차
+              </span>
+              <span className="rounded-full border border-gray-100 bg-gray-50 px-3 py-1">
+                {formatDuration(report.durationSec)}
+              </span>
+            </div>
+          </div>
+          <p className="text-sm text-gray-600">{report.leaderName}님과의 미팅</p>
+        </header>
+
+        <section className="mb-6">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-950">오늘의 성과</h2>
+            <span className="text-sm font-semibold text-gray-500">
+              {report.confirmedAchievements.length}개
+            </span>
+          </div>
+          <Card className="p-4">
+            <div className="grid gap-3 lg:grid-cols-2">
+              {report.confirmedAchievements.map((achievement) => (
+                <AchievementCard key={achievement.careerEventId} achievement={achievement} />
+              ))}
+            </div>
+          </Card>
+        </section>
+
+        <section>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-950">리더의 약속 장부</h2>
+            <span className="text-sm font-semibold text-gray-500">{sortedPromises.length}개</span>
+          </div>
+          <Card className="p-4">
+            <ul className="space-y-3">
+              {sortedPromises.map((promise) => (
+                <PromiseItem key={promise.promiseId} promise={promise} />
+              ))}
+            </ul>
+          </Card>
+        </section>
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/pages/member/SurveyPage.tsx
+++ b/src/pages/member/SurveyPage.tsx
@@ -2,19 +2,40 @@ import { useParams } from 'react-router-dom';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
 import SurveyForm from '@/components/survey/SurveyForm';
+import { useMeetingDetail } from '@/features/meeting/useMeetingDetail';
 
 export default function SurveyPage() {
   const { meetingId } = useParams<{ meetingId: string }>();
+  const { meeting, loading, error } = useMeetingDetail(meetingId);
+  const parsedMeetingId = meetingId ? Number(meetingId) : 0;
+
+  const renderContent = () => {
+    if (!meetingId || Number.isNaN(parsedMeetingId)) {
+      return <p className="text-center text-sm text-slate-500">유효하지 않은 미팅입니다.</p>;
+    }
+
+    if (loading) {
+      return <p className="text-center text-sm text-slate-500">미팅 정보를 불러오는 중입니다.</p>;
+    }
+
+    if (error || !meeting) {
+      return <p className="text-center text-sm text-slate-500">{error ?? '미팅 정보를 찾을 수 없습니다.'}</p>;
+    }
+
+    return (
+      <SurveyForm
+        leaderName={meeting.leaderName}
+        scheduledAt={meeting.scheduledAt}
+        meetingId={parsedMeetingId}
+      />
+    );
+  };
 
   return (
     <PageLayout>
       <Header title="1on1 사전 설문" />
       <main className="min-h-[calc(100vh-3.5rem)] bg-[#F7F8FA] px-5 py-8 text-gray-900">
-        <SurveyForm
-          leaderName="이준혁"
-          scheduledAt="2026-04-29T09:00:00.000Z"
-          meetingId={meetingId ? (Number.isNaN(Number(meetingId)) ? 0 : Number(meetingId)) : 0}
-        />
+        {renderContent()}
       </main>
     </PageLayout>
   );

--- a/src/types/memberReport.ts
+++ b/src/types/memberReport.ts
@@ -1,0 +1,38 @@
+export type MemberAchievementType = 'ACHIEVEMENT' | 'PROPOSAL_ADOPTED';
+export type MemberPromiseCategory = 'RESOURCE' | 'TEAM_BUILDING' | 'RECOGNITION' | 'PROCESS';
+export type MemberPromiseStatus = 'PENDING' | 'DONE';
+
+export interface MemberReportApiResponse {
+  success: boolean;
+  code: string;
+  message: string;
+  data: MemberReportData;
+}
+
+export interface MemberReportData {
+  meetingId: number;
+  round: number;
+  leaderName: string;
+  meetingDate: string;
+  durationSec: number;
+  confirmedAchievements: ConfirmedAchievement[];
+  leaderPromises: LeaderPromise[];
+}
+
+export interface ConfirmedAchievement {
+  careerEventId: number;
+  type: MemberAchievementType;
+  title: string;
+  description: string;
+  impactMetric: string;
+  leaderQuote: string;
+  leaderName: string;
+}
+
+export interface LeaderPromise {
+  promiseId: number;
+  content: string;
+  category: MemberPromiseCategory;
+  dueDate: string;
+  status: MemberPromiseStatus;
+}


### PR DESCRIPTION
### **멤버 미팅 후 리포트 페이지 추가** 
**summary**
- 1on1 미팅 이후 멤버가 확인할 수 있는 멤버 측 리포트 페이지 추가

**변경 페이지 및 파일**
`src/pages/member/MemberReportPage.tsx`
  - 오늘의 성과 영역 추가
  - 리더의 약속 장부 영역 추가
  - 성과 타입별 표시 처리
    - `ACHIEVEMENT` → `#성취`
    - `PROPOSAL_ADOPTED` → `#기여`
  - 약속 상태별 표시 처리
    - 진행 중: 흰색 카드, 상태 텍스트 초록색
    - 완료: 회색 카드

`src/api/meetings.ts`

`src/features/member/useMemberReport.ts`
  - 멤버 리포트 조회 hook 및 mock 모드 

`src/data/mockMemberReport.ts`: 테스트 용 mock 데이터 

`src/types/memberReport.ts`: 멤버 리포트 응답 타입 추가

`src/app/router.tsx`: 멤버 리포트 라우트 추가

**Mock 데이터로 화면 확인**  
1. `.env` 설정
VITE_USE_MOCK=true
2. npm.cmd run dev
3. http://localhost:5173/member/meeting/10/report 접속 



### **서베이 백엔드 연결**
**Summary**
서베이 제출 플로우를 백엔드 API와 연결
리더 미팅 상세 화면에서 서베이 완료 여부를 확인할 수 있도록 임시 훅 추가 

**변경 페이지/파일**

`src/components/survey/SurveyForm.tsx`
- 서베이 선택지를 백엔드 형태에 맞게 수정 
- 제출 중/성공/실패 상태 처리
- 중복 제출, 권한 없음, 미팅 없음 에러 메시지 처리

`src/pages/member/SurveyPage.tsx`
- 미팅 정보 조회 후 설문 렌더링

`src/pages/leader/MeetingDetailPage.tsx`
- useSurveyCompletion으로 서베이 제출 여부 확인 (임시) 
- 서베이 완료 시 미팅 시작 버튼 활성화

`src/api/meetings.ts`
- 서베이 관련 타입 추가

`src/features/meeting/useSurveyCompletion.ts`
- 서베이 완료 여부 polling 훅 추가
