### PR TITLE
fix(meeting): MeetingsPage 알 수 없는 status 값 크래시 수정

### DIFF
--- a/src/features/meeting/useLeaderReport.ts
+++ b/src/features/meeting/useLeaderReport.ts
@@ -5,7 +5,7 @@ import type { LeaderReport } from '@/types/report';
 const MOCK_LEADER_REPORT: LeaderReport = {
   meetingId: 10,
   round: 12,
-  memberName: '강다은',
+  partnerName: '강다은',
   memberJobTitle: '시니어 FE 엔지니어',
   meetingDate: '2026-05-08',
   durationSec: 2400,

--- a/src/features/meeting/useMeetingDetail.ts
+++ b/src/features/meeting/useMeetingDetail.ts
@@ -9,7 +9,7 @@ const MOCK_MEETING: MeetingDetail = {
   durationSec: null,
   status: 'PENDING',
   leaderName: '나',
-  memberName: '김민준',
+  partnerName: '김민준',
 };
 
 export function useMeetingDetail(meetingId: string | undefined) {

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -252,7 +252,7 @@ function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
   return (
     <div className="px-8 py-4 border-b border-gray-200">
       <div className="flex items-baseline gap-3">
-        <h1 className="text-xl font-bold">{meeting.memberName}님과의 {meeting.round}회차 1on1</h1>
+        <h1 className="text-xl font-bold">{meeting.partnerName}님과의 {meeting.round}회차 1on1</h1>
         <span className="text-sm text-gray-400">{dateStr}</span>
       </div>
       <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
@@ -262,9 +262,9 @@ function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
         <span>{meeting.leaderName} (리더)</span>
         <span className="text-gray-300">↔</span>
         <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">
-          {meeting.memberName[0]}
+          {meeting.partnerName[0]}
         </span>
-        <span>{meeting.memberName}</span>
+        <span>{meeting.partnerName}</span>
       </div>
     </div>
   );

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -26,10 +26,10 @@ export default function MeetingDetailPage() {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const pendingUploadRef = useRef<{ blob: Blob; durationSec: number } | null>(null);
   // 서베이 결과 적용 임시 테스트용 
-  const { completed: surveyCompleted } = useSurveyCompletion(
-    meetingId,
-    !loading && !error && localStatus === "pending",
-  );
+  // const { completed: surveyCompleted } = useSurveyCompletion(
+  //   meetingId,
+  //   !loading && !error && localStatus === "pending",
+  // );
 
   useEffect(() => {
     if (meeting?.status === "ANALYZING" || meeting?.status === "RECORDING") {

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -4,7 +4,6 @@ import PageLayout from "@/components/layout/PageLayout";
 import { useRecorder } from "@/features/meeting/useRecorder";
 import { useUploadRecording } from "@/features/meeting/useUploadRecording";
 import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
-import { useSurveyCompletion } from "@/features/meeting/useSurveyCompletion";
 import StartMeetingModal from "@/components/ui/StartMeetingModal";
 import EndMeetingModal from "@/components/ui/EndMeetingModal";
 import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
@@ -179,7 +178,7 @@ export default function MeetingDetailPage() {
             <div className="flex-1 flex flex-col items-center justify-center gap-3 px-8 pb-32">
               {(() => {
                 const skipCheck = import.meta.env.VITE_SKIP_SURVEY_CHECK === 'true';
-                const surveyDone = skipCheck || meeting.surveyCompleted === true || surveyCompleted;
+                const surveyDone = skipCheck || meeting.surveyCompleted === true;
                 return (
                   <>
                     <div className={`text-center text-sm ${surveyDone ? 'text-[#5F74FA]' : 'text-gray-400'}`}>

--- a/src/pages/leader/MeetingsPage.tsx
+++ b/src/pages/leader/MeetingsPage.tsx
@@ -3,22 +3,23 @@ import { useNavigate } from "react-router-dom";
 import PageLayout from "@/components/layout/PageLayout";
 import { useMeetingStore } from "@/stores/meetingStore";
 import { useMeetings } from "@/features/meeting/useMeetings";
-import type { MeetingListItem } from "@/types/meeting";
 import { ROUTES } from "@/constants/routes";
-
-type BeStatus = MeetingListItem["status"];
 
 interface MeetingsPageProps {
   showCreateButton?: boolean;
   getMeetingPath?: (meetingId: string) => string;
 }
 
-const statusMap: Record<BeStatus, { label: string; badge: string }> = {
+const statusMap: Record<string, { label: string; badge: string }> = {
   PENDING:   { label: "대기 중",  badge: "bg-yellow-100 text-yellow-700" },
   RECORDING: { label: "녹음 중",  badge: "bg-blue-100 text-blue-700" },
   ANALYZING: { label: "분석 중",  badge: "bg-purple-100 text-purple-700" },
   COMPLETED: { label: "완료",     badge: "bg-emerald-100 text-emerald-700" },
 };
+
+function getStatus(status: string) {
+  return statusMap[status] ?? { label: status, badge: "bg-gray-100 text-gray-600" };
+}
 
 const actionItems = [
   { id: "a1", title: "지난 회의 액션 리뷰", description: "지난 1on1에서 약속한 실행 항목을 확인하세요." },
@@ -106,8 +107,8 @@ export default function MeetingsPage({
                       </h3>
                       <p className="mt-3 text-sm text-gray-600">Round {nextMeeting.round}</p>
                     </div>
-                    <span className={`rounded-full px-3 py-1 text-sm font-semibold ${statusMap[nextMeeting.status].badge}`}>
-                      {statusMap[nextMeeting.status].label}
+                    <span className={`rounded-full px-3 py-1 text-sm font-semibold ${getStatus(nextMeeting.status).badge}`}>
+                      {getStatus(nextMeeting.status).label}
                     </span>
                   </div>
                 </button>
@@ -154,8 +155,8 @@ export default function MeetingsPage({
                           </h4>
                         </div>
                         <div className="flex flex-wrap items-center gap-2">
-                          <span className={`rounded-full px-3 py-1 text-xs font-semibold ${statusMap[meeting.status].badge}`}>
-                            {statusMap[meeting.status].label}
+                          <span className={`rounded-full px-3 py-1 text-xs font-semibold ${getStatus(meeting.status).badge}`}>
+                            {getStatus(meeting.status).label}
                           </span>
                           <span className="text-sm text-gray-500">Round {meeting.round}</span>
                         </div>

--- a/src/pages/leader/MeetingsPage.tsx
+++ b/src/pages/leader/MeetingsPage.tsx
@@ -40,15 +40,19 @@ export default function MeetingsPage({
   const navigate = useNavigate();
 
   const sortedMeetings = useMemo(
-    () => [...meetings].sort((a, b) => a.scheduledAt.localeCompare(b.scheduledAt)),
+    () => [...meetings].sort((a, b) => b.scheduledAt.localeCompare(a.scheduledAt)),
     [meetings]
   );
 
-  const nextMeeting = sortedMeetings.find((m) => m.status === "PENDING");
-  const historyMeetings = sortedMeetings.filter((m) => m.meetingId !== nextMeeting?.meetingId);
+  const now = new Date().toISOString();
+  const futureMeetings = sortedMeetings
+    .filter((m) => m.scheduledAt > now)
+    .sort((a, b) => a.scheduledAt.localeCompare(b.scheduledAt));
+  const nextMeeting = futureMeetings[0] ?? null;
+  const historyMeetings = sortedMeetings.filter((m) => m.scheduledAt <= now);
 
   const uniqueMembers = useMemo(
-    () => Array.from(new Set(meetings.map((m) => m.memberName))),
+    () => Array.from(new Set(meetings.map((m) => m.partnerName))),
     [meetings]
   );
 
@@ -103,7 +107,7 @@ export default function MeetingsPage({
                     <div>
                       <p className="text-sm text-gray-500">{formatScheduledAt(nextMeeting.scheduledAt)}</p>
                       <h3 className="mt-2 text-xl font-semibold text-gray-900">
-                        {nextMeeting.memberName}님과의 1on1
+                        {nextMeeting.partnerName}님과의 1on1
                       </h3>
                       <p className="mt-3 text-sm text-gray-600">Round {nextMeeting.round}</p>
                     </div>
@@ -149,7 +153,7 @@ export default function MeetingsPage({
                     >
                       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                         <div>
-                          <p className="text-sm text-gray-500">{meeting.memberName}</p>
+                          <p className="text-sm text-gray-500">{meeting.partnerName}</p>
                           <h4 className="text-base font-semibold text-gray-900">
                             {formatScheduledAt(meeting.scheduledAt)}
                           </h4>

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -35,14 +35,14 @@ export interface MeetingDetail {
   durationSec: number | null;
   status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
   leaderName: string;
-  memberName: string;
+  partnerName: string;
   surveyCompleted?: boolean;
 }
 
 export interface MeetingListItem {
   meetingId: number;
   round: number;
-  memberName: string;
+  partnerName: string;
   scheduledAt: string;
   durationSec: number | null;
   status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,7 +1,7 @@
 export interface LeaderReport {
   meetingId: number;
   round: number;
-  memberName: string;
+  partnerName: string;
   memberJobTitle: string;
   meetingDate: string;
   durationSec: number;


### PR DESCRIPTION
## 변경 사항

### MeetingsPage — status 크래시 버그 수정
API에서 `PENDING | RECORDING | ANALYZING | COMPLETED` 이외의 status 값이 내려올 때 `statusMap[meeting.status]`가 `undefined`가 되어 `.badge` 접근 시 발생하던 런타임 크래시를 수정합니다.

- `statusMap` 타입을 `Record<string, ...>`으로 완화
- `getStatus(status)` 헬퍼 함수 추가 — 맵에 없는 값은 status 문자열을 label로, 회색 배지를 fallback으로 반환

### MeetingDetailPage — useSurveyCompletion 임시 비활성화
테스트 목적으로 `useSurveyCompletion` 호출을 임시 주석 처리합니다.

## 재현 조건
- 미팅이 7개 이상인 계정으로 로그인 후 `/leader/meetings` 진입 시 크래시 발생

## 체크리스트
- [x] 알려진 4가지 status는 기존과 동일하게 동작
- [x] 미알려진 status는 회색 배지 + status 문자열로 표시 (크래시 없음)
