### PR TITLE
feat: 리더 리포트 갭 분석 섹션 개선 및 미팅 상세 화면 수정

### DIFF
--- a/src/components/loading/AnalysisLoading.tsx
+++ b/src/components/loading/AnalysisLoading.tsx
@@ -57,7 +57,7 @@ export default function AnalysisLoading({ role, recordingDuration, meetingId, on
       <div className="border-b border-gray-200 px-8 py-4">
         <p className="text-sm text-gray-500">🎙️ 녹음 완료 {formatDuration(recordingDuration)}</p>
         <div className="flex gap-4 mt-4 -mb-[1px]">
-          {["미팅 본문", "요약", "분석"].map((tab, i) => (
+          {["미팅 분석", "리더 맞춤 피드백"].map((tab, i) => (
             <button
               key={tab}
               className={`pb-2 text-sm font-medium ${

--- a/src/components/report/GapsSection.tsx
+++ b/src/components/report/GapsSection.tsx
@@ -83,11 +83,6 @@ export default function GapsSection({ data }: Props) {
   const honestyBorder = riskBorderColors[honestyGap.riskLevel] ?? 'border-gray-200';
   const honestyDonutColor = riskDonutColors[honestyGap.riskLevel] ?? '#22c55e';
 
-  const executionRatio =
-    executionGap.totalPromises === 0
-      ? 0
-      : executionGap.fulfilled / executionGap.totalPromises;
-
   return (
     <div>
       <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
@@ -154,8 +149,8 @@ export default function GapsSection({ data }: Props) {
             Execution Gap
           </p>
           <GapDonut
-            ratio={executionRatio}
-            fillColor={executionGap.totalPromises === 0 ? '#d1d5db' : '#22c55e'}
+            ratio={executionGap.score / 100}
+            fillColor="#22c55e"
             centerLabel={String(executionGap.score)}
             subLabel="/100"
           />

--- a/src/components/report/GapsSection.tsx
+++ b/src/components/report/GapsSection.tsx
@@ -1,22 +1,77 @@
+import { PieChart, Pie, Cell } from 'recharts';
+import Badge from '@/components/ui/Badge';
 import type { Gaps } from '@/types/report';
 
-const riskColors: Record<string, string> = {
-  DANGER: 'bg-red-100 text-red-700',
-  WARNING: 'bg-yellow-100 text-yellow-700',
-  SAFE: 'bg-green-100 text-green-700',
+const EMPTY_COLOR = '#f3f4f6';
+
+const riskBorderColors: Record<string, string> = {
+  DANGER: 'border-red-300',
+  WARNING: 'border-orange-300',
+  CAUTION: 'border-yellow-300',
+  SAFE: 'border-gray-200',
 };
 
-const riskLabels: Record<string, string> = {
-  DANGER: '위험',
-  WARNING: '주의',
-  SAFE: '안전',
+const riskDonutColors: Record<string, string> = {
+  DANGER: '#ef4444',
+  WARNING: '#f97316',
+  CAUTION: '#eab308',
+  SAFE: '#22c55e',
+};
+
+const riskBadgeColors: Record<string, 'red' | 'orange' | 'yellow' | 'green'> = {
+  DANGER: 'red',
+  WARNING: 'orange',
+  CAUTION: 'yellow',
+  SAFE: 'green',
+};
+
+const riskBadgeLabels: Record<string, string> = {
+  DANGER: 'Danger',
+  WARNING: 'Warning',
+  CAUTION: 'Caution',
+  SAFE: 'Safe',
 };
 
 const directionLabels: Record<string, string> = {
-  OVERREPORT: '과장 보고',
-  UNDERREPORT: '축소 보고',
-  ALIGNED: '일치',
+  OVERREPORT: 'Overreporting',
+  UNDERREPORT: 'Underreporting',
+  ALIGNED: 'Aligned',
 };
+
+interface GapDonutProps {
+  ratio: number;
+  fillColor: string;
+  centerLabel: string;
+  subLabel?: string;
+}
+
+function GapDonut({ ratio, fillColor, centerLabel, subLabel }: GapDonutProps) {
+  const clamped = Math.max(0, Math.min(1, ratio));
+  return (
+    <div className="relative w-[120px] h-[120px] mx-auto">
+      <PieChart width={120} height={120}>
+        <Pie
+          data={[{ value: clamped }, { value: 1 - clamped }]}
+          cx={60}
+          cy={60}
+          innerRadius={40}
+          outerRadius={52}
+          startAngle={90}
+          endAngle={-270}
+          dataKey="value"
+          strokeWidth={0}
+        >
+          <Cell fill={fillColor} />
+          <Cell fill={EMPTY_COLOR} />
+        </Pie>
+      </PieChart>
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <span className="text-2xl font-bold text-gray-900 leading-none">{centerLabel}</span>
+        {subLabel && <span className="text-xs text-gray-400 mt-0.5">{subLabel}</span>}
+      </div>
+    </div>
+  );
+}
 
 interface Props {
   data: Gaps;
@@ -25,52 +80,68 @@ interface Props {
 export default function GapsSection({ data }: Props) {
   const { alignmentGap, honestyGap, executionGap } = data;
 
+  const honestyBorder = riskBorderColors[honestyGap.riskLevel] ?? 'border-gray-200';
+  const honestyDonutColor = riskDonutColors[honestyGap.riskLevel] ?? '#22c55e';
+
+  const executionRatio =
+    executionGap.totalPromises === 0
+      ? 0
+      : executionGap.fulfilled / executionGap.totalPromises;
+
   return (
     <div>
       <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
-        갭 분석
+        Gap Analysis
       </h3>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+
         {/* Alignment Gap */}
-        <div className="rounded-xl border border-gray-200 p-4 flex flex-col gap-2">
+        <div className="rounded-xl border border-gray-200 p-4 flex flex-col gap-3">
           <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
-            정렬 갭
+            Alignment Gap
           </p>
-          <div className="flex items-end gap-1">
-            <span className="text-3xl font-bold text-gray-900">{alignmentGap.score}</span>
-            <span className="text-sm text-gray-400 mb-1">/100</span>
-          </div>
+          <GapDonut
+            ratio={alignmentGap.score / 100}
+            fillColor="#5F74FA"
+            centerLabel={String(alignmentGap.score)}
+            subLabel="/100"
+          />
           <p className="text-xs text-gray-500 leading-relaxed">{alignmentGap.detail}</p>
         </div>
 
         {/* Honesty Gap */}
-        <div className="rounded-xl border border-gray-200 p-4 flex flex-col gap-2">
+        <div className={`rounded-xl border p-4 flex flex-col gap-3 ${honestyBorder}`}>
           <div className="flex items-center justify-between">
             <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
-              정직 갭
+              Honesty Gap
             </p>
-            <span
-              className={`text-xs font-semibold px-2 py-0.5 rounded-full ${riskColors[honestyGap.riskLevel]}`}
-            >
-              {riskLabels[honestyGap.riskLevel]}
-            </span>
+            <Badge
+              label={riskBadgeLabels[honestyGap.riskLevel] ?? honestyGap.riskLevel}
+              color={riskBadgeColors[honestyGap.riskLevel] ?? 'gray'}
+            />
           </div>
-          <div className="flex items-end gap-1">
-            <span className="text-3xl font-bold text-gray-900">{honestyGap.gap}</span>
-            <span className="text-sm text-gray-400 mb-1">점 차이</span>
-          </div>
+          <GapDonut
+            ratio={Math.min(honestyGap.gap, 100) / 100}
+            fillColor={honestyDonutColor}
+            centerLabel={String(honestyGap.gap)}
+            subLabel="pt gap"
+          />
           <div className="flex flex-col gap-1 text-xs text-gray-500">
             <div className="flex justify-between">
-              <span>설문 점수</span>
+              <span>Survey Score</span>
               <span className="font-medium text-gray-700">{honestyGap.surveyScore}</span>
             </div>
             <div className="flex justify-between">
-              <span>심리적 안전감</span>
+              <span>Safety Score</span>
               <span className="font-medium text-gray-700">{honestyGap.safetyScore}</span>
             </div>
             <div className="flex justify-between">
-              <span>방향</span>
-              <span className="font-medium text-gray-700">
+              <span>Direction</span>
+              <span
+                className={`font-medium ${
+                  honestyGap.direction === 'OVERREPORT' ? 'text-orange-500' : 'text-gray-700'
+                }`}
+              >
                 {directionLabels[honestyGap.direction]}
               </span>
             </div>
@@ -78,36 +149,29 @@ export default function GapsSection({ data }: Props) {
         </div>
 
         {/* Execution Gap */}
-        <div className="rounded-xl border border-gray-200 p-4 flex flex-col gap-2">
+        <div className="rounded-xl border border-gray-200 p-4 flex flex-col gap-3">
           <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
-            실행 갭
+            Execution Gap
           </p>
-          <div className="flex items-end gap-1">
-            <span className="text-3xl font-bold text-gray-900">{executionGap.score}</span>
-            <span className="text-sm text-gray-400 mb-1">/100</span>
-          </div>
+          <GapDonut
+            ratio={executionRatio}
+            fillColor={executionGap.totalPromises === 0 ? '#d1d5db' : '#22c55e'}
+            centerLabel={String(executionGap.score)}
+            subLabel="/100"
+          />
           <div className="flex flex-col gap-1 text-xs text-gray-500">
             <div className="flex justify-between">
-              <span>이행</span>
-              <span className="font-medium text-green-600">{executionGap.fulfilled}건</span>
+              <span>Fulfilled</span>
+              <span className="font-medium text-green-600">{executionGap.fulfilled} done</span>
             </div>
             <div className="flex justify-between">
-              <span>미이행</span>
-              <span className="font-medium text-red-500">{executionGap.missed}건</span>
+              <span>Missed</span>
+              <span className="font-bold text-red-500">{executionGap.missed} missed</span>
             </div>
           </div>
-          {/* Mini progress bar */}
-          <div className="w-full h-1.5 rounded-full bg-gray-100 overflow-hidden mt-1">
-            <div
-              className="h-full rounded-full bg-green-400"
-              style={{
-                width: `${executionGap.totalPromises === 0 ? 0 : (executionGap.fulfilled / executionGap.totalPromises) * 100}%`,
-              }}
-            />
-          </div>
         </div>
+
       </div>
     </div>
   );
 }
-

--- a/src/components/report/GapsSection.tsx
+++ b/src/components/report/GapsSection.tsx
@@ -3,6 +3,7 @@ import Badge from '@/components/ui/Badge';
 import type { Gaps } from '@/types/report';
 
 const EMPTY_COLOR = '#f3f4f6';
+const ALIGNED_COLOR = '#d1d5db'; // gray-300, inconspicuous shared-score region
 
 const riskBorderColors: Record<string, string> = {
   DANGER: 'border-red-300',
@@ -73,6 +74,47 @@ function GapDonut({ ratio, fillColor, centerLabel, subLabel }: GapDonutProps) {
   );
 }
 
+interface HonestyGapDonutProps {
+  surveyScore: number;
+  safetyScore: number;
+  gap: number;
+  riskLevel: string;
+}
+
+function HonestyGapDonut({ surveyScore, safetyScore, gap, riskLevel }: HonestyGapDonutProps) {
+  const s = Math.max(0, Math.min(100, surveyScore));
+  const f = Math.max(0, Math.min(100, safetyScore));
+  const aligned = Math.min(s, f) / 100;
+  const diff = Math.abs(s - f) / 100;
+  const empty = Math.max(0, 1 - aligned - diff);
+  const gapColor = riskDonutColors[riskLevel] ?? '#22c55e';
+  return (
+    <div className="relative w-[120px] h-[120px] mx-auto">
+      <PieChart width={120} height={120}>
+        <Pie
+          data={[{ value: diff }, { value: aligned }, { value: empty }]}
+          cx={60}
+          cy={60}
+          innerRadius={40}
+          outerRadius={52}
+          startAngle={90}
+          endAngle={-270}
+          dataKey="value"
+          strokeWidth={0}
+        >
+          <Cell fill={gapColor} />
+          <Cell fill={ALIGNED_COLOR} />
+          <Cell fill={EMPTY_COLOR} />
+        </Pie>
+      </PieChart>
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <span className="text-2xl font-bold text-gray-900 leading-none">{gap}</span>
+        <span className="text-xs text-gray-400 mt-0.5">pt gap</span>
+      </div>
+    </div>
+  );
+}
+
 interface Props {
   data: Gaps;
 }
@@ -81,7 +123,6 @@ export default function GapsSection({ data }: Props) {
   const { alignmentGap, honestyGap, executionGap } = data;
 
   const honestyBorder = riskBorderColors[honestyGap.riskLevel] ?? 'border-gray-200';
-  const honestyDonutColor = riskDonutColors[honestyGap.riskLevel] ?? '#22c55e';
 
   return (
     <div>
@@ -115,11 +156,11 @@ export default function GapsSection({ data }: Props) {
               color={riskBadgeColors[honestyGap.riskLevel] ?? 'gray'}
             />
           </div>
-          <GapDonut
-            ratio={Math.min(honestyGap.gap, 100) / 100}
-            fillColor={honestyDonutColor}
-            centerLabel={String(honestyGap.gap)}
-            subLabel="pt gap"
+          <HonestyGapDonut
+            surveyScore={honestyGap.surveyScore}
+            safetyScore={honestyGap.safetyScore}
+            gap={honestyGap.gap}
+            riskLevel={honestyGap.riskLevel}
           />
           <div className="flex flex-col gap-1 text-xs text-gray-500">
             <div className="flex justify-between">
@@ -131,7 +172,7 @@ export default function GapsSection({ data }: Props) {
               <span className="font-medium text-gray-700">{honestyGap.safetyScore}</span>
             </div>
             <div className="flex justify-between">
-              <span>Direction</span>
+              <span>상태</span>
               <span
                 className={`font-medium ${
                   honestyGap.direction === 'OVERREPORT' ? 'text-orange-500' : 'text-gray-700'
@@ -156,12 +197,12 @@ export default function GapsSection({ data }: Props) {
           />
           <div className="flex flex-col gap-1 text-xs text-gray-500">
             <div className="flex justify-between">
-              <span>Fulfilled</span>
-              <span className="font-medium text-green-600">{executionGap.fulfilled} done</span>
+              <span>이행</span>
+              <span className="font-medium text-green-600">{executionGap.fulfilled} 개</span>
             </div>
             <div className="flex justify-between">
-              <span>Missed</span>
-              <span className="font-bold text-red-500">{executionGap.missed} missed</span>
+              <span>미이행</span>
+              <span className="font-bold text-red-500">{executionGap.missed} 개</span>
             </div>
           </div>
         </div>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,12 +1,13 @@
 interface BadgeProps {
   label: string;
-  color?: 'red' | 'yellow' | 'green' | 'gray';
+  color?: 'red' | 'yellow' | 'orange' | 'green' | 'gray';
 }
 
 export default function Badge({ label, color = 'gray' }: BadgeProps) {
   const colors = {
     red: 'bg-red-100 text-red-700',
     yellow: 'bg-yellow-100 text-yellow-700',
+    orange: 'bg-orange-100 text-orange-700',
     green: 'bg-green-100 text-green-700',
     gray: 'bg-gray-100 text-gray-600',
   };

--- a/src/components/ui/StartMeetingModal.tsx
+++ b/src/components/ui/StartMeetingModal.tsx
@@ -34,11 +34,7 @@ export default function StartMeetingModal({ isOpen, onClose, onStart }: Props) {
             ON
           </div>
         </div>
-
-        <div className="bg-gray-50 rounded-lg p-3 mb-6 text-sm text-gray-500">
-          🎙️ 마이크를 선택하세요
-        </div>
-
+        
         <label className="flex items-center gap-2 mb-6 cursor-pointer">
           <input
             type="checkbox"

--- a/src/features/meeting/useMeetingDetail.ts
+++ b/src/features/meeting/useMeetingDetail.ts
@@ -9,7 +9,7 @@ const MOCK_MEETING: MeetingDetail = {
   durationSec: null,
   status: 'PENDING',
   leaderName: '나',
-  partnerName: '김민준',
+  memberName: '김민준',
 };
 
 export function useMeetingDetail(meetingId: string | undefined) {

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -178,7 +178,7 @@ export default function MeetingDetailPage() {
             <div className="flex-1 flex flex-col items-center justify-center gap-3 px-8 pb-32">
               {(() => {
                 const skipCheck = import.meta.env.VITE_SKIP_SURVEY_CHECK === 'true';
-                const surveyDone = skipCheck || meeting.surveyCompleted === true;
+                const surveyDone = skipCheck || meeting.surveySubmitted === true;
                 return (
                   <>
                     <div className={`text-center text-sm ${surveyDone ? 'text-[#5F74FA]' : 'text-gray-400'}`}>

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -252,7 +252,7 @@ function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
   return (
     <div className="px-8 py-4 border-b border-gray-200">
       <div className="flex items-baseline gap-3">
-        <h1 className="text-xl font-bold">{meeting.partnerName}님과의 {meeting.round}회차 1on1</h1>
+        <h1 className="text-xl font-bold">{meeting.memberName}님과의 {meeting.round}회차 1on1</h1>
         <span className="text-sm text-gray-400">{dateStr}</span>
       </div>
       <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
@@ -262,9 +262,9 @@ function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
         <span>{meeting.leaderName} (리더)</span>
         <span className="text-gray-300">↔</span>
         <span className="w-6 h-6 rounded-full bg-pink-400 flex items-center justify-center text-white text-xs">
-          {meeting.partnerName[0]}
+          {meeting.memberName[0]}
         </span>
-        <span>{meeting.partnerName}</span>
+        <span>{meeting.memberName}</span>
       </div>
     </div>
   );

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -103,9 +103,9 @@ export default function MeetingDetailPage() {
   if (localStatus === "uploading") {
     return (
       <PageLayout>
-        <div className="flex flex-col">
+        <div className="flex flex-col h-full">
           <MeetingHeader meeting={meeting} />
-          <div className="flex-1 flex flex-col items-center justify-center px-8 gap-4">
+          <div className="flex-1 flex flex-col items-center justify-center px-8 gap-4 pb-32">
             <div className="w-10 h-10 border-4 border-[#5F74FA] border-t-transparent rounded-full animate-spin" />
             <p className="text-sm text-gray-600">녹음 파일을 업로드 중입니다...</p>
           </div>
@@ -250,12 +250,12 @@ function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
   });
 
   return (
-    <div className="px-8 py-4 border-b border-gray-200">
+    <div className="px-8 pt-6 pb-4 border-b border-gray-200">
       <div className="flex items-baseline gap-3">
-        <h1 className="text-xl font-bold">{meeting.memberName}님과의 {meeting.round}회차 1on1</h1>
+        <h1 className="text-2xl font-bold">{meeting.memberName}님과의 {meeting.round}회차 1on1</h1>
         <span className="text-sm text-gray-400">{dateStr}</span>
       </div>
-      <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
+      <div className="flex items-center gap-2 mt-2 text-sm text-gray-500">
         <span className="w-6 h-6 rounded-full bg-[#5F74FA] flex items-center justify-center text-white text-xs">
           {meeting.leaderName[0]}
         </span>

--- a/src/pages/leader/MeetingsPage.tsx
+++ b/src/pages/leader/MeetingsPage.tsx
@@ -11,6 +11,7 @@ interface MeetingsPageProps {
 }
 
 const statusMap: Record<string, { label: string; badge: string }> = {
+  CREATED:   { label: "대기 중",  badge: "bg-yellow-100 text-yellow-700" },
   PENDING:   { label: "대기 중",  badge: "bg-yellow-100 text-yellow-700" },
   RECORDING: { label: "녹음 중",  badge: "bg-blue-100 text-blue-700" },
   ANALYZING: { label: "분석 중",  badge: "bg-purple-100 text-purple-700" },

--- a/src/pages/member/MeetingDetailPage.tsx
+++ b/src/pages/member/MeetingDetailPage.tsx
@@ -79,9 +79,9 @@ function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
   });
 
   return (
-    <div className="px-8 py-4 border-b border-gray-200">
-      <h1 className="text-xl font-bold">{dateStr}</h1>
-      <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
+    <div className="px-8 pt-6 pb-4 border-b border-gray-200">
+      <h1 className="text-2xl font-bold">{dateStr}</h1>
+      <div className="flex items-center gap-2 mt-2 text-sm text-gray-500">
         <span className="w-6 h-6 rounded-full bg-[#5F74FA] flex items-center justify-center text-white text-xs">
           {meeting.leaderName[0]}
         </span>

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -36,7 +36,7 @@ export interface MeetingDetail {
   status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
   leaderName: string;
   memberName: string;
-  surveyCompleted?: boolean;
+  surveySubmitted?: boolean;
 }
 
 export interface MeetingListItem {

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -35,7 +35,7 @@ export interface MeetingDetail {
   durationSec: number | null;
   status: "PENDING" | "RECORDING" | "ANALYZING" | "COMPLETED";
   leaderName: string;
-  partnerName: string;
+  memberName: string;
   surveyCompleted?: boolean;
 }
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -30,7 +30,7 @@ export interface HonestyGap {
   safetyScore: number;
   gap: number;
   direction: 'OVERREPORT' | 'UNDERREPORT' | 'ALIGNED';
-  riskLevel: 'DANGER' | 'WARNING' | 'SAFE';
+  riskLevel: 'DANGER' | 'WARNING' | 'CAUTION' | 'SAFE';
 }
 
 export interface ExecutionGap {


### PR DESCRIPTION
## Summary

- **GapsSection 개선**: 갭 분석 3개 카드에 도넛 차트 추가 (Recharts PieChart), 갭 이름 한국어 → 영어 변경 (Alignment / Honesty / Execution Gap)
- **Honesty Gap 강조**: riskLevel에 따른 카드 테두리·도넛 색상 분기, Badge 표시 (DANGER/WARNING/CAUTION/SAFE), 3색 세그먼트 도넛(gap 위험도 색 → 공통 구간 gray → 빈 영역)
- **타입 확장**: `HonestyGap.riskLevel`에 `'CAUTION'` 추가, `Badge` 컴포넌트에 `orange` 색상 추가
- **미팅 상세 화면**: UI 개선, CREATED 상태 표시 수정, 서베이 완료 변수명 수정

## Test Plan
- [ ] 분석 탭 → Gap Analysis 섹션에서 3개 카드 도넛 차트 렌더링 확인
- [ ] Honesty Gap riskLevel별 카드 테두리·Badge·도넛 색상 확인 (DANGER=빨강, WARNING=주황, CAUTION=노랑, SAFE=초록)
- [ ] Honesty Gap 도넛: gap 세그먼트(위험도 색) → 공통 세그먼트(gray-300) → 빈 영역(gray-100) 순서 확인
- [ ] Alignment / Execution Gap 도넛 정상 렌더링 확인
