### PR TITLE
#FEAT: 사이드바 항목 정리 및 멤버 커리어 메모리 연결

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -20,15 +20,6 @@ const CalendarIcon = () => (
   </svg>
 );
 
-const UsersIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-    <circle cx="9" cy="7" r="4" />
-    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
-    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-  </svg>
-);
-
 const BarChartIcon = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
     <line x1="18" y1="20" x2="18" y2="10" />
@@ -54,26 +45,6 @@ const UserPlusIcon = () => (
   </svg>
 );
 
-const BellIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
-    <path d="M13.73 21a2 2 0 0 1-3.46 0" />
-  </svg>
-);
-
-const BookIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-  </svg>
-);
-
-const ChevronRightIcon = () => (
-  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <polyline points="9 18 15 12 9 6" />
-  </svg>
-);
-
 const LogoutIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -84,13 +55,11 @@ const LogoutIcon = () => (
 
 const navItems: NavItem[] = [
   { label: '1on1 미팅', path: '/leader/meetings', icon: <CalendarIcon /> },
-  { label: '멤버 리포트', path: '/leader/reports', icon: <UsersIcon /> },
   { label: '팀 인사이트 대시보드', path: '/leader/dashboard', icon: <BarChartIcon /> },
 ];
 
 const bottomItems = [
   { label: '설정', path: '/settings', icon: <SettingsIcon /> },
-  { label: '멤버 초대하기', path: '/invite', icon: <UserPlusIcon /> },
 ];
 
 export default function Sidebar() {
@@ -148,11 +117,14 @@ export default function Sidebar() {
     });
   };
 
-  const roleNavItems = navItems.map((item) =>
-    user?.role === 'member' && item.path === '/leader/meetings'
-      ? { ...item, path: '/member/meetings' }
-      : item
-  );
+  const roleNavItems = navItems.map((item) => {
+    if (user?.role !== 'member') return item;
+    if (item.path === '/leader/meetings') return { ...item, path: '/member/meetings' };
+    if (item.path === '/leader/dashboard') {
+      return { ...item, label: '나의 커리어 메모리', path: '/member/dashboard' };
+    }
+    return item;
+  });
 
   const isMeetingActive =
     location.pathname === '/leader/meetings' ||
@@ -314,24 +286,6 @@ export default function Sidebar() {
             {item.label}
           </NavLink>
         ))}
-      </div>
-
-      {/* Footer links */}
-      <div className="px-3 pb-2">
-        <button className="flex items-center justify-between w-full px-3 py-1.5 text-xs text-gray-400 hover:text-gray-600 transition-colors rounded-lg hover:bg-gray-50">
-          <div className="flex items-center gap-2">
-            <BellIcon />
-            <span>업데이트 노트</span>
-          </div>
-          <ChevronRightIcon />
-        </button>
-        <button className="flex items-center justify-between w-full px-3 py-1.5 text-xs text-gray-400 hover:text-gray-600 transition-colors rounded-lg hover:bg-gray-50">
-          <div className="flex items-center gap-2">
-            <BookIcon />
-            <span>서비스 가이드</span>
-          </div>
-          <ChevronRightIcon />
-        </button>
       </div>
 
       {/* User Profile */}


### PR DESCRIPTION
### **사이드바 메뉴 정리**

- Footer links(업데이트 노트, 서비스 가이드) 제거
- 멤버 사이드바 대시보드 항목을 나의 커리어 메모리로 변경
- 멤버 리포트 항목 제거 