### PR TITLE
FIX: 멤버 리포트 데이터 형식 정규화 및 데이터 부재 시 상태 메시지 추가

### DIFF
--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -50,11 +50,30 @@ function normalizeDate(value: unknown, fallback: string) {
   return typeof value === 'string' && value.trim() !== '' ? value : fallback;
 }
 
+function normalizeReportDate(value: unknown, fallback: string) {
+  const normalized = normalizeDate(value, fallback).slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : fallback.slice(0, 10);
+}
+
+function normalizeDurationSec(value: unknown) {
+  const duration = typeof value === 'string' ? Number(value) : value;
+  return typeof duration === 'number' && Number.isFinite(duration) && duration > 0
+    ? duration
+    : null;
+}
+
 function normalizeMemberReport(report: MemberReportData): MemberReportData {
-  const fallbackDate = normalizeDate(report.meetingDate, new Date().toISOString()).slice(0, 10);
+  const rawReport = report as MemberReportData & {
+    durationSec?: unknown;
+    meetingDate?: unknown;
+  };
+  const fallbackDate = new Date().toISOString().slice(0, 10);
+  const meetingDate = normalizeReportDate(rawReport.meetingDate, fallbackDate);
 
   return {
     ...report,
+    meetingDate,
+    durationSec: normalizeDurationSec(rawReport.durationSec),
     leaderPromises: (report.leaderPromises ?? []).map((promise, index) => {
       const rawPromise = promise as LeaderPromise & {
         category?: unknown;
@@ -69,7 +88,7 @@ function normalizeMemberReport(report: MemberReportData): MemberReportData {
         category: isPromiseCategory(rawPromise.category)
           ? rawPromise.category
           : DEFAULT_PROMISE_CATEGORY,
-        dueDate: normalizeDate(rawPromise.dueDate, fallbackDate),
+        dueDate: normalizeReportDate(rawPromise.dueDate, meetingDate),
         status: isPromiseStatus(rawPromise.status) ? rawPromise.status : DEFAULT_PROMISE_STATUS,
       };
     }),

--- a/src/pages/member/MemberReportPage.tsx
+++ b/src/pages/member/MemberReportPage.tsx
@@ -43,12 +43,17 @@ const statusLabels: Record<MemberPromiseStatus, string> = {
   DONE: '완료',
 };
 
-function formatDuration(durationSec: number) {
+function formatDuration(durationSec: number | null) {
+  if (!durationSec || durationSec <= 0) return '-';
   return `${Math.floor(durationSec / 60)}분`;
 }
 
 function formatDate(date: string) {
-  return new Date(`${date}T00:00:00`).toLocaleDateString('ko-KR', {
+  const normalizedDate = date.slice(0, 10);
+  const parsedDate = new Date(`${normalizedDate}T00:00:00`);
+  if (Number.isNaN(parsedDate.getTime())) return '-';
+
+  return parsedDate.toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -189,11 +194,15 @@ export default function MemberReportPage() {
             </span>
           </div>
           <Card className="p-4">
-            <div className="grid gap-3 lg:grid-cols-2">
-              {report.confirmedAchievements.map((achievement) => (
-                <AchievementCard key={achievement.careerEventId} achievement={achievement} />
-              ))}
-            </div>
+            {report.confirmedAchievements.length === 0 ? (
+              <p className="py-6 text-center text-sm text-gray-500">분석 결과가 없습니다.</p>
+            ) : (
+              <div className="grid gap-3 lg:grid-cols-2">
+                {report.confirmedAchievements.map((achievement) => (
+                  <AchievementCard key={achievement.careerEventId} achievement={achievement} />
+                ))}
+              </div>
+            )}
           </Card>
         </section>
 
@@ -203,11 +212,15 @@ export default function MemberReportPage() {
             <span className="text-sm font-semibold text-gray-500">{sortedPromises.length}개</span>
           </div>
           <Card className="p-4">
-            <ul className="space-y-3">
-              {sortedPromises.map((promise) => (
-                <PromiseItem key={promise.promiseId} promise={promise} />
-              ))}
-            </ul>
+            {sortedPromises.length === 0 ? (
+              <p className="py-6 text-center text-sm text-gray-500">분석 결과가 없습니다.</p>
+            ) : (
+              <ul className="space-y-3">
+                {sortedPromises.map((promise) => (
+                  <PromiseItem key={promise.promiseId} promise={promise} />
+                ))}
+              </ul>
+            )}
           </Card>
         </section>
       </div>

--- a/src/types/memberReport.ts
+++ b/src/types/memberReport.ts
@@ -14,7 +14,7 @@ export interface MemberReportData {
   round: number;
   leaderName: string;
   meetingDate: string;
-  durationSec: number;
+  durationSec: number | null;
   confirmedAchievements: ConfirmedAchievement[];
   leaderPromises: LeaderPromise[];
 }


### PR DESCRIPTION
### **Summary**

- 멤버 리포트 화면에서 API 응답값이 비어 있거나 형식이 달라도 UI가 깨지지 않도록 방어 처리 추가
- 성과/약속 데이터가 없을 때 빈 상태 메시지 표시

### **변경 사항**

- meetingDate가 datetime으로 내려와도 date-only 형식으로 정규화
- durationSec가 없거나 유효하지 않으면 0분 대신 - 표시
- 잘못된 날짜 값이 들어오면 Invalid Date 대신 - 표시
- 오늘의 성과 / 리더 약속 장부 데이터가 없으면 분석 결과가 없습니다. 표시

### **변경 파일**

src/api/meetings.ts
src/types/memberReport.ts
src/pages/member/MemberReportPage.tsx