### PR TITLE
#FIX: 자기소개 기본 멘트 추가 및 PDF 저장 기능 활성화

### DIFF
--- a/src/components/career/CareerProfileCard.tsx
+++ b/src/components/career/CareerProfileCard.tsx
@@ -20,6 +20,10 @@ function StatItem({ value, label }: { value: string | number; label: string }) {
 }
 
 export default function CareerProfileCard({ stats }: CareerProfileCardProps) {
+  const displayJobTitle = stats.jobTitle?.trim() || '팀원';
+  const displayAiSummary =
+    stats.aiSummary?.trim() || `${stats.teamName}팀의 ${displayJobTitle} 입니다.`;
+
   return (
     <Card className="rounded-lg border-gray-100 p-5 shadow-sm sm:p-6">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
@@ -48,7 +52,8 @@ export default function CareerProfileCard({ stats }: CareerProfileCardProps) {
             type="button"
             variant="secondary"
             size="sm"
-            className="rounded-lg border border-gray-200 bg-gray-50 text-slate-700 hover:bg-gray-100"
+            onClick={() => window.print()}
+            className="rounded-lg border border-gray-200 bg-gray-50 text-slate-700 hover:bg-gray-100 print:hidden"
           >
             PDF 저장
           </Button>
@@ -56,7 +61,7 @@ export default function CareerProfileCard({ stats }: CareerProfileCardProps) {
       </div>
 
       <div className="mt-6 border-t border-gray-100 pt-4">
-        <p className="text-sm font-medium leading-6 text-slate-500">"{stats.aiSummary}"</p>
+        <p className="text-sm font-medium leading-6 text-slate-500">"{displayAiSummary}"</p>
       </div>
     </Card>
   );


### PR DESCRIPTION
### **Summary**
- 커리어 프로필 카드의 AI 요약 기본 문구 추가
-  PDF 저장 버튼에 브라우저 인쇄 기능 연결
### **변경 사항**

- stats.aiSummary가 비어 있으면 {팀명}팀의 {직무} 입니다. 기본 문구 표시
- stats.jobTitle이 비어 있으면 팀원으로 대체
- PDF 저장 버튼 클릭 시 window.print() 실행

### **변경 파일**

src/components/career/CareerProfileCard.tsx