### PR TITLE
fix, feat: 미팅 목록 표시 오류 수정, 사이드바 접기 토글 추가 (localStorage 유지)

### DIFF
--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,7 +1,10 @@
-import { type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import Sidebar from './Sidebar';
 import CreateMeetingModal from '@/components/ui/CreateMeetingModal';
 import { useMeetingStore } from '@/stores/meetingStore';
+
+const COLLAPSED_WIDTH = 60;
+const EXPANDED_WIDTH = 220;
 
 interface PageLayoutProps {
   children: ReactNode;
@@ -9,18 +12,31 @@ interface PageLayoutProps {
 
 export default function PageLayout({ children }: PageLayoutProps) {
   const { isCreateModalOpen, setCreateModalOpen } = useMeetingStore();
+  const [isCollapsed, setIsCollapsed] = useState(
+    () => localStorage.getItem('sidebar-collapsed') === 'true'
+  );
+
+  const handleToggle = () => {
+    setIsCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem('sidebar-collapsed', String(next));
+      return next;
+    });
+  };
+
+  const sidebarWidth = isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH;
 
   return (
     <div className="flex h-screen overflow-hidden bg-white">
-      <Sidebar />
+      <Sidebar isCollapsed={isCollapsed} onToggle={handleToggle} />
       <main
-        style={{ marginLeft: 'var(--sidebar-width)' }}
+        style={{ marginLeft: sidebarWidth, transition: 'margin-left 200ms ease' }}
         className="flex-1 overflow-y-auto"
       >
         {children}
       </main>
-      <CreateMeetingModal 
-        isOpen={isCreateModalOpen} 
+      <CreateMeetingModal
+        isOpen={isCreateModalOpen}
         onClose={() => setCreateModalOpen(false)}
         onCreated={() => {
           setCreateModalOpen(false);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -62,7 +62,12 @@ const bottomItems = [
   { label: '설정', path: '/settings', icon: <SettingsIcon /> },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  isCollapsed: boolean;
+  onToggle: () => void;
+}
+
+export default function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
   const setCreateModalOpen = useMeetingStore((s) => s.setCreateModalOpen);
   const location = useLocation();
   const user = useMe();
@@ -100,6 +105,13 @@ export default function Sidebar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [teamMenuOpen]);
 
+  useEffect(() => {
+    if (isCollapsed) {
+      setTeamMenuOpen(false);
+      setProfileMenuOpen(false);
+    }
+  }, [isCollapsed]);
+
   const handleSectionToggle = (section: 'members' | 'inviteCode') => {
     if (activeSection === section) {
       setActiveSection(null);
@@ -134,33 +146,85 @@ export default function Sidebar() {
 
   return (
     <aside
-      style={{ width: 'var(--sidebar-width)', background: '#F8F9FA', borderRight: '1px solid #E9ECEF' }}
-      className="fixed left-0 top-0 h-full flex flex-col bg-white border-r border-gray-100 z-20"
+      style={{
+        width: isCollapsed ? '60px' : '220px',
+        transition: 'width 200ms ease',
+        background: '#F8F9FA',
+        borderRight: '1px solid #E9ECEF',
+      }}
+      className="fixed left-0 top-0 h-full flex flex-col z-20"
     >
+      {/* Toggle Button — trapezoid tab on right edge */}
+      <button
+        onClick={onToggle}
+        aria-label={isCollapsed ? '사이드바 펼치기' : '사이드바 접기'}
+        style={{
+          position: 'absolute',
+          right: -10,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          width: '10px',
+          height: '40px',
+          background: '#E9ECEF',
+          border: 'none',
+          borderRadius: '0 4px 4px 0',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 30,
+          padding: 0,
+          clipPath: isCollapsed
+            ? 'polygon(0 10%, 100% 0%, 100% 100%, 0 90%)'
+            : 'polygon(0 0%, 100% 10%, 100% 90%, 0 100%)',
+          transition: 'background 150ms ease, clip-path 200ms ease',
+        }}
+        onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#CED4DA'; }}
+        onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#E9ECEF'; }}
+      >
+        <svg
+          width="6"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#6B7280"
+          strokeWidth="3"
+          style={{ flexShrink: 0 }}
+        >
+          {isCollapsed
+            ? <polyline points="9 18 15 12 9 6" />
+            : <polyline points="15 18 9 12 15 6" />
+          }
+        </svg>
+      </button>
       {/* Workspace */}
       <div className="relative px-4 pt-5 pb-3 border-b border-gray-100" ref={teamMenuRef}>
         <button
           onClick={() => setTeamMenuOpen((prev) => !prev)}
-          className="flex items-center gap-2 w-full px-2 py-1.5 rounded-lg hover:bg-gray-50 transition-colors"
+          className={`flex items-center gap-2 w-full px-2 py-1.5 rounded-lg transition-colors ${isCollapsed ? 'justify-center' : 'hover:bg-gray-50'}`}
         >
-          <div className="w-6 h-6 rounded bg-gray-800 flex items-center justify-center">
+          <div className="w-6 h-6 rounded bg-gray-800 flex items-center justify-center flex-shrink-0">
             <span className="text-white text-xs font-bold">
               {user?.teamName?.[0]?.toUpperCase() ?? 'T'}
             </span>
           </div>
-          <span className="text-sm font-semibold text-gray-800 flex-1 text-left truncate">
-            {user?.teamName ?? '...'}
-          </span>
-          <svg
-            width="12" height="12" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" strokeWidth="2"
-            className={`flex-shrink-0 transition-transform duration-150 ${teamMenuOpen ? 'rotate-180' : ''}`}
-          >
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
+          {!isCollapsed && (
+            <>
+              <span className="text-sm font-semibold text-gray-800 flex-1 text-left truncate">
+                {user?.teamName ?? '...'}
+              </span>
+              <svg
+                width="12" height="12" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth="2"
+                className={`flex-shrink-0 transition-transform duration-150 ${teamMenuOpen ? 'rotate-180' : ''}`}
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </>
+          )}
         </button>
 
-        {teamMenuOpen && (
+        {!isCollapsed && teamMenuOpen && (
           <div className="absolute left-2 right-2 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-30 overflow-hidden">
             {/* 소속 멤버 */}
             <button
@@ -241,12 +305,16 @@ export default function Sidebar() {
       </div>
 
       {/* New 1on1 Button */}
-      <div className={user?.role === 'leader' ? 'px-4 pt-3 pb-2' : 'hidden'}>
+      <div className={user?.role === 'leader' ? (isCollapsed ? 'flex justify-center pt-3 pb-2' : 'px-4 pt-3 pb-2') : 'hidden'}>
         <button
           onClick={() => setCreateModalOpen(true)}
-          className="w-full py-2.5 bg-black text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-colors flex items-center justify-center gap-2"
+          className={
+            isCollapsed
+              ? 'w-8 h-8 bg-black text-white rounded-lg text-base font-medium hover:bg-gray-800 transition-colors flex items-center justify-center'
+              : 'w-full py-2.5 bg-black text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-colors flex items-center justify-center gap-2'
+          }
         >
-          새 1on1 만들기
+          {isCollapsed ? '+' : '새 1on1 만들기'}
         </button>
       </div>
 
@@ -265,10 +333,10 @@ export default function Sidebar() {
                 isActive
                   ? 'bg-gray-200 text-gray-900 font-medium'
                   : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-              }`}
+              } ${isCollapsed ? 'justify-center' : ''}`}
             >
-              <span className="text-gray-500">{item.icon}</span>
-              {item.label}
+              <span className="text-gray-500 flex-shrink-0">{item.icon}</span>
+              {!isCollapsed && item.label}
             </NavLink>
           );
         })}
@@ -280,17 +348,17 @@ export default function Sidebar() {
           <NavLink
             key={item.path}
             to={item.path}
-            className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm mb-0.5 text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors"
+            className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm mb-0.5 text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors ${isCollapsed ? 'justify-center' : ''}`}
           >
-            <span className="text-gray-500">{item.icon}</span>
-            {item.label}
+            <span className="text-gray-500 flex-shrink-0">{item.icon}</span>
+            {!isCollapsed && item.label}
           </NavLink>
         ))}
       </div>
 
       {/* User Profile */}
       <div className="relative" ref={profileRef}>
-        {profileMenuOpen && (
+        {!isCollapsed && profileMenuOpen && (
           <div className="absolute bottom-full left-4 right-4 mb-1 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden z-30">
             <button
               onClick={logout}
@@ -303,7 +371,7 @@ export default function Sidebar() {
         )}
         <div className="px-4 py-3 border-t border-gray-100">
           <button
-            className="flex items-center gap-2 w-full rounded-lg hover:bg-gray-50 transition-colors px-1 py-0.5 disabled:cursor-default"
+            className={`flex items-center gap-2 w-full rounded-lg hover:bg-gray-50 transition-colors px-1 py-0.5 disabled:cursor-default ${isCollapsed ? 'justify-center' : ''}`}
             onClick={() => setProfileMenuOpen((prev) => !prev)}
             disabled={!user}
           >
@@ -312,15 +380,17 @@ export default function Sidebar() {
                 {user?.name?.[0] ?? '?'}
               </span>
             </div>
-            <div className="min-w-0 text-left">
-              <p className="text-sm font-medium text-gray-800 truncate">
-                {user?.name ?? '...'}
-              </p>
-              <p className="text-xs text-gray-400 truncate">{user?.email ?? ''}</p>
-              {user?.jobTitle && (
-                <p className="text-xs text-gray-400 truncate">{user.jobTitle}</p>
-              )}
-            </div>
+            {!isCollapsed && (
+              <div className="min-w-0 text-left">
+                <p className="text-sm font-medium text-gray-800 truncate">
+                  {user?.name ?? '...'}
+                </p>
+                <p className="text-xs text-gray-400 truncate">{user?.email ?? ''}</p>
+                {user?.jobTitle && (
+                  <p className="text-xs text-gray-400 truncate">{user.jobTitle}</p>
+                )}
+              </div>
+            )}
           </button>
         </div>
       </div>

--- a/src/pages/leader/MeetingsPage.tsx
+++ b/src/pages/leader/MeetingsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import PageLayout from "@/components/layout/PageLayout";
 import { useMeetingStore } from "@/stores/meetingStore";
@@ -45,12 +45,23 @@ export default function MeetingsPage({
     [meetings]
   );
 
-  const now = new Date().toISOString();
+  const [showAllFuture, setShowAllFuture] = useState(false);
+  const [historyPage, setHistoryPage] = useState(1);
+
+  const now = new Date();
+  const isWithinGrace = (scheduledAt: string) => {
+    const d = new Date(scheduledAt);
+    d.setMinutes(d.getMinutes() + 30);
+    return d > now;
+  };
+
   const futureMeetings = sortedMeetings
-    .filter((m) => m.scheduledAt > now)
+    .filter((m) => isWithinGrace(m.scheduledAt) && m.status !== 'COMPLETED')
     .sort((a, b) => a.scheduledAt.localeCompare(b.scheduledAt));
-  const nextMeeting = futureMeetings[0] ?? null;
-  const historyMeetings = sortedMeetings.filter((m) => m.scheduledAt <= now);
+  const visibleFutureMeetings = showAllFuture ? futureMeetings : futureMeetings.slice(0, 3);
+  const historyMeetings = sortedMeetings.filter(
+    (m) => !isWithinGrace(m.scheduledAt) || m.status === 'COMPLETED'
+  );
 
   const uniqueMembers = useMemo(
     () => Array.from(new Set(meetings.map((m) => m.partnerName))),
@@ -90,7 +101,7 @@ export default function MeetingsPage({
                   <h2 className="mt-2 text-2xl font-semibold text-gray-900">다음 1on1 일정</h2>
                 </div>
                 <span className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600">
-                  총 {meetings.length}개
+                  총 {futureMeetings.length}건
                 </span>
               </div>
 
@@ -98,28 +109,42 @@ export default function MeetingsPage({
                 <div className="mt-6 rounded-3xl border border-gray-200 bg-gray-50 p-8 text-center text-gray-400 animate-pulse">
                   불러오는 중...
                 </div>
-              ) : nextMeeting ? (
-                <button
-                  type="button"
-                  onClick={() => navigate(getMeetingPath(String(nextMeeting.meetingId)))}
-                  className="mt-6 w-full rounded-3xl border border-blue-100 bg-blue-50 p-6 text-left shadow-sm transition hover:border-blue-200 hover:bg-blue-100"
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-4">
-                    <div>
-                      <p className="text-sm text-gray-500">{formatScheduledAt(nextMeeting.scheduledAt)}</p>
-                      <h3 className="mt-2 text-xl font-semibold text-gray-900">
-                        {nextMeeting.partnerName}님과의 1on1
-                      </h3>
-                      <p className="mt-3 text-sm text-gray-600">Round {nextMeeting.round}</p>
-                    </div>
-                    <span className={`rounded-full px-3 py-1 text-sm font-semibold ${getStatus(nextMeeting.status).badge}`}>
-                      {getStatus(nextMeeting.status).label}
-                    </span>
-                  </div>
-                </button>
-              ) : (
+              ) : futureMeetings.length === 0 ? (
                 <div className="mt-6 rounded-3xl border border-dashed border-gray-200 bg-gray-50 p-8 text-center text-gray-500">
                   예정된 미팅이 없습니다.
+                </div>
+              ) : (
+                <div className="mt-6 space-y-3">
+                  {visibleFutureMeetings.map((meeting) => (
+                    <button
+                      key={meeting.meetingId}
+                      type="button"
+                      onClick={() => navigate(getMeetingPath(String(meeting.meetingId)))}
+                      className="w-full rounded-3xl border border-blue-100 bg-blue-50 p-6 text-left shadow-sm transition hover:border-blue-200 hover:bg-blue-100"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-4">
+                        <div>
+                          <p className="text-sm text-gray-500">{formatScheduledAt(meeting.scheduledAt)}</p>
+                          <h3 className="mt-2 text-xl font-semibold text-gray-900">
+                            {meeting.partnerName}님과의 1on1
+                          </h3>
+                          <p className="mt-3 text-sm text-gray-600">Round {meeting.round}</p>
+                        </div>
+                        <span className={`rounded-full px-3 py-1 text-sm font-semibold ${getStatus(meeting.status).badge}`}>
+                          {getStatus(meeting.status).label}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                  {futureMeetings.length > 3 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowAllFuture((prev) => !prev)}
+                      className="w-full rounded-3xl border border-gray-200 bg-gray-50 py-3 text-sm font-medium text-gray-500 transition hover:bg-gray-100"
+                    >
+                      {showAllFuture ? '접기 ▲' : `${futureMeetings.length - 3}개 더 보기 ▼`}
+                    </button>
+                  )}
                 </div>
               )}
             </section>

--- a/src/pages/leader/MeetingsPage.tsx
+++ b/src/pages/leader/MeetingsPage.tsx
@@ -63,6 +63,13 @@ export default function MeetingsPage({
     (m) => !isWithinGrace(m.scheduledAt) || m.status === 'COMPLETED'
   );
 
+  const HISTORY_PAGE_SIZE = 10;
+  const totalHistoryPages = Math.max(1, Math.ceil(historyMeetings.length / HISTORY_PAGE_SIZE));
+  const paginatedHistory = historyMeetings.slice(
+    (historyPage - 1) * HISTORY_PAGE_SIZE,
+    historyPage * HISTORY_PAGE_SIZE
+  );
+
   const uniqueMembers = useMemo(
     () => Array.from(new Set(meetings.map((m) => m.partnerName))),
     [meetings]
@@ -169,31 +176,56 @@ export default function MeetingsPage({
                   아직 기록된 미팅이 없습니다.
                 </div>
               ) : (
-                <div className="space-y-3">
-                  {historyMeetings.map((meeting) => (
-                    <button
-                      key={meeting.meetingId}
-                      type="button"
-                      onClick={() => navigate(getMeetingPath(String(meeting.meetingId)))}
-                      className="w-full rounded-3xl border border-gray-200 bg-gray-50 p-4 text-left transition hover:border-gray-300 hover:bg-gray-100"
-                    >
-                      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                        <div>
-                          <p className="text-sm text-gray-500">{meeting.partnerName}</p>
-                          <h4 className="text-base font-semibold text-gray-900">
-                            {formatScheduledAt(meeting.scheduledAt)}
-                          </h4>
+                <>
+                  <div className="space-y-3">
+                    {paginatedHistory.map((meeting) => (
+                      <button
+                        key={meeting.meetingId}
+                        type="button"
+                        onClick={() => navigate(getMeetingPath(String(meeting.meetingId)))}
+                        className="w-full rounded-3xl border border-gray-200 bg-gray-50 p-4 text-left transition hover:border-gray-300 hover:bg-gray-100"
+                      >
+                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                          <div>
+                            <p className="text-sm text-gray-500">{meeting.partnerName}</p>
+                            <h4 className="text-base font-semibold text-gray-900">
+                              {formatScheduledAt(meeting.scheduledAt)}
+                            </h4>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className={`rounded-full px-3 py-1 text-xs font-semibold ${getStatus(meeting.status).badge}`}>
+                              {getStatus(meeting.status).label}
+                            </span>
+                            <span className="text-sm text-gray-500">Round {meeting.round}</span>
+                          </div>
                         </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className={`rounded-full px-3 py-1 text-xs font-semibold ${getStatus(meeting.status).badge}`}>
-                            {getStatus(meeting.status).label}
-                          </span>
-                          <span className="text-sm text-gray-500">Round {meeting.round}</span>
-                        </div>
-                      </div>
-                    </button>
-                  ))}
-                </div>
+                      </button>
+                    ))}
+                  </div>
+                  {totalHistoryPages > 1 && (
+                    <div className="mt-4 flex items-center justify-center gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setHistoryPage((p) => Math.max(1, p - 1))}
+                        disabled={historyPage === 1}
+                        className="rounded-full border border-gray-200 px-3 py-1 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+                      >
+                        ◀ 이전
+                      </button>
+                      <span className="text-sm text-gray-500">
+                        {historyPage} / {totalHistoryPages}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setHistoryPage((p) => Math.min(totalHistoryPages, p + 1))}
+                        disabled={historyPage === totalHistoryPages}
+                        className="rounded-full border border-gray-200 px-3 py-1 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+                      >
+                        다음 ▶
+                      </button>
+                    </div>
+                  )}
+                </>
               )}
             </section>
           </div>


### PR DESCRIPTION
## Summary

- 예정 미팅 목록 표시 오류 수정 — 단건 표시에서 전체 목록 렌더링으로 변경, 가장 가까운 3개 표시 후 더 보기/접기 토글
- 미팅 기록 섹션 페이지네이션 추가 — 10개 단위 분할, 10개 이하일 때 UI 미표시
- 사이드바 접기/펼치기 토글 추가 — 오른쪽 가장자리 탭 버튼, localStorage로 상태 유지

## Changes

**`MeetingsPage.tsx`**
- 예정 미팅 카운트 뱃지를 전체 미팅 수 → 예정 미팅 수로 수정
- 시간 기준 분류에 30분 유예 적용 (지각 고려)
- COMPLETED 상태 미팅은 시간 무관하게 미팅 기록으로 이동
- 미팅 기록 10개 단위 페이지네이션

**`PageLayout.tsx` / `Sidebar.tsx`**
- PageLayout에서 isCollapsed 상태 관리, localStorage 초기화 및 저장
- 사이드바 오른쪽 가장자리 세로 중앙에 탭형 토글 버튼 (200ms ease 애니메이션)
- 접힌 상태(60px): 아이콘만 표시, 텍스트·드롭다운 숨김

## Test plan

- [ ] 예정 미팅이 여러 건일 때 가장 가까운 3개만 표시되고 "더 보기" 토글이 동작하는지 확인
- [ ] COMPLETED 미팅이 시간과 무관하게 미팅 기록 섹션에 표시되는지 확인
- [ ] 미팅 기록이 10개 초과일 때 페이지네이션이 표시되고 10개 이하일 때 숨겨지는지 확인
- [ ] 사이드바 토글 버튼 클릭 시 60px ↔ 220px 애니메이션 전환 확인
- [ ] 새로고침 후 사이드바 접힘 상태 유지 확인
- [ ] 접힌 상태에서 아이콘만 표시, 팀/프로필 드롭다운 비활성화 확인
