### PR TITLE
#FEAT: Pre-Meeting Briefing 구현

### DIFF
--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -1,6 +1,6 @@
 import apiClient from './client';
 import type { ApiResponse } from './types';
-import type { MeetingDetail, MeetingListItem } from '@/types/meeting';
+import type { MeetingDetail, MeetingListItem, PreBriefingData } from '@/types/meeting';
 import type {
   LeaderPromise,
   MemberPromiseCategory,
@@ -97,6 +97,13 @@ function normalizeMemberReport(report: MemberReportData): MemberReportData {
 
 export async function fetchMeetingDetail(meetingId: string): Promise<MeetingDetail> {
   const res = await apiClient.get<ApiResponse<MeetingDetail>>(`/api/v1/meetings/${meetingId}`);
+  return res.data.data;
+}
+
+export async function fetchPreBriefing(meetingId: string): Promise<PreBriefingData> {
+  const res = await apiClient.get<ApiResponse<PreBriefingData>>(
+    `/api/v1/meetings/${meetingId}/pre-briefing`,
+  );
   return res.data.data;
 }
 

--- a/src/components/charts/BlockerPyramid.tsx
+++ b/src/components/charts/BlockerPyramid.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type MouseEvent } from 'react';
-import type { BlockerPyramidColor, BlockerPyramidItem } from '@/types/blocker';
+import { getBlockerRankColor } from '@/utils/blockerColors';
+import type { BlockerPyramidItem } from '@/types/blocker';
 
 export interface BlockerPyramidProps {
   items: BlockerPyramidItem[];
@@ -13,13 +14,6 @@ type TooltipState = {
   x: number;
   y: number;
 } | null;
-
-const PALETTE: BlockerPyramidColor[] = [
-  { bg: '#FFECEF', text: '#FA5252', border: '#F8B4C0' },
-  { bg: '#FEFCE8', text: '#eb9925', border: '#FDE68A' },
-  { bg: '#EAF5FF', text: '#2563EB', border: '#BBD7FF' },
-  { bg: '#F4F4F5', text: '#52525B', border: '#D4D4D8' },
-];
 
 const TAG_ROW_PATTERN = [1, 3, 6];
 
@@ -40,13 +34,6 @@ function getRank(sortedItems: BlockerPyramidItem[], index: number) {
 
     return rank;
   }, 1);
-}
-
-export function getBlockerRankColor(rank: number) {
-  if (rank === 1) return PALETTE[0];
-  if (rank === 2 || rank === 3 || rank === 4) return PALETTE[1];
-  if (rank === 5 || rank === 6 || rank === 7) return PALETTE[2];
-  return PALETTE[3];
 }
 
 function getPillStyle(

--- a/src/components/meeting/PreBriefingCard.tsx
+++ b/src/components/meeting/PreBriefingCard.tsx
@@ -1,0 +1,280 @@
+import Badge from '@/components/ui/Badge';
+import type { PreBriefingData } from '@/types/meeting';
+import { getBlockerRankColor } from '@/utils/blockerColors';
+
+interface Props {
+  data: PreBriefingData;
+}
+
+const quadrantLabels: Record<string, string> = {
+  STABLE: 'STABLE',
+  SILENT_RISK: 'SILENT RISK',
+  EXPLICIT_RISK: 'EXPLICIT RISK',
+  CONSERVATIVE: 'CONSERVATIVE',
+};
+
+const quadrantColors: Record<string, 'red' | 'yellow' | 'orange' | 'green' | 'gray'> = {
+  STABLE: 'green',
+  SILENT_RISK: 'orange',
+  EXPLICIT_RISK: 'red',
+  CONSERVATIVE: 'yellow',
+};
+
+const riskColors: Record<string, 'red' | 'yellow' | 'orange' | 'green' | 'gray'> = {
+  DANGER: 'red',
+  WARNING: 'orange',
+  CAUTION: 'yellow',
+  SAFE: 'green',
+};
+
+function formatSchedule(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function formatScore(value: number | null | undefined) {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : '-';
+}
+
+function formatChange(value: number | null) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '이전 평균 없음';
+  if (value > 0) return `+${Math.round(value)} vs 이전`;
+  if (value < 0) return `${Math.round(value)} vs 이전`;
+  return '변화 없음';
+}
+
+function getInitials(name: string) {
+  return name.trim().slice(-2) || '?';
+}
+
+function TagList({ items, emptyText }: { items: string[]; emptyText: string }) {
+  if (items.length === 0) {
+    return <p className="text-xs text-gray-400">{emptyText}</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {items.map((item) => (
+        <span
+          key={item}
+          className="rounded-md bg-gray-100 px-2.5 py-1 text-[11px] font-medium text-gray-600"
+        >
+          {item}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function BlockerTagList({ items, emptyText }: { items: string[]; emptyText: string }) {
+  if (items.length === 0) {
+    return <p className="text-xs text-gray-400">{emptyText}</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {items.map((item, index) => {
+        const color = getBlockerRankColor(index + 1);
+
+        return (
+          <span
+            key={`${item}-${index}`}
+            className="rounded-md px-2.5 py-1 text-[11px] font-medium"
+            style={{
+              backgroundColor: color.bg,
+              border: `1px solid ${color.border}`,
+              color: color.text,
+            }}
+          >
+            {item}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function PreBriefingCard({ data }: Props) {
+  const lastMeeting = data.lastMeeting;
+  const overdueCount = data.pendingPromises.filter((promise) => promise.overdue).length;
+
+  return (
+    <section className="w-full max-w-[560px] rounded-xl border border-gray-100 bg-white px-6 py-5 shadow-sm">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#EEF2FF] text-sm font-semibold text-[#4E62E6]">
+            {getInitials(data.memberName)}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-[15px] font-semibold text-gray-900">
+              {data.memberName}님과의 {data.round}회차 1on1
+            </p>
+            <p className="mt-0.5 truncate text-xs text-gray-500">
+              {formatSchedule(data.scheduledAt)} · {data.memberJobTitle || '직무 정보 없음'}
+            </p>
+          </div>
+        </div>
+        {lastMeeting?.quadrant && (
+          <Badge
+            label={quadrantLabels[lastMeeting.quadrant] ?? lastMeeting.quadrant}
+            color={quadrantColors[lastMeeting.quadrant] ?? 'gray'}
+          />
+        )}
+      </div>
+
+      {lastMeeting ? (
+        <div className="mb-4 grid grid-cols-1 gap-2.5 border-t border-gray-100 pt-3.5 sm:grid-cols-3">
+          <MetricCard
+            label="Safety score"
+            value={formatScore(lastMeeting.safetyScore)}
+            hint={formatChange(lastMeeting.safetyScoreChange)}
+            color={{ bg: '#EEF2FF', border: '#C7D2FE', text: '#5F74FA' }}
+          />
+          <MetricCard
+            label="Honesty gap"
+            value={lastMeeting.honestyGap?.direction ?? '-'}
+            hint={lastMeeting.honestyGap?.riskLevel ?? '데이터 없음'}
+            color={{ bg: '#FFF7ED', border: '#FDBA74', text: '#f97316' }}
+          />
+          <MetricCard
+            label="Survey score"
+            value={formatScore(data.survey.surveyScore)}
+            hint={data.survey.submitted ? '사전 서베이 제출' : '서베이 미제출'}
+            color={{ bg: '#F0FDF4', border: '#BBF7D0', text: '#22c55e' }}
+          />
+        </div>
+      ) : (
+        <div className="mb-4 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-500">
+          첫 미팅이라 이전 미팅 데이터가 없습니다.
+        </div>
+      )}
+
+      <Section title="사전 서베이">
+        {data.survey.submitted ? (
+          <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
+            <div className="rounded-lg bg-gray-50 px-3 py-2 text-center">
+              <p className="text-[11px] text-gray-500">Energy</p>
+              <p className="mt-1 text-xl font-semibold text-gray-900">
+                {data.survey.energyLevel ?? '-'}
+              </p>
+            </div>
+            <div className="flex flex-col gap-2">
+              <TagList items={data.survey.issues} emptyText="선택한 이슈가 없습니다." />
+              <TagList items={data.survey.desiredRoles} emptyText="기대 역할이 없습니다." />
+            </div>
+          </div>
+        ) : (
+          <p className="rounded-lg bg-gray-50 px-3 py-2 text-xs text-gray-500">
+            멤버가 아직 서베이를 제출하지 않았습니다.
+          </p>
+        )}
+      </Section>
+
+      {(data.pendingPromises.length > 0 || (lastMeeting?.speechActAlerts.length ?? 0) > 0) && (
+        <Section title="주의 포인트">
+          <div className="flex flex-col gap-2">
+            {data.pendingPromises.length > 0 && (
+              <div
+                className={`rounded-lg px-3 py-2 ${
+                  overdueCount > 0 ? 'bg-red-50 text-red-700' : 'bg-yellow-50 text-yellow-700'
+                }`}
+              >
+                <p className="text-xs font-semibold">
+                  미이행 약속 {data.pendingPromises.length}건
+                  {overdueCount > 0 ? ` · 지연 ${overdueCount}건` : ''}
+                </p>
+                <p className="mt-1 text-[11px] text-gray-600">
+                  {data.pendingPromises.map((promise) => promise.content).join(' · ')}
+                </p>
+              </div>
+            )}
+            {lastMeeting?.speechActAlerts.map((alert) => (
+              <div key={alert} className="rounded-lg bg-gray-50 px-3 py-2">
+                <p className="text-xs font-medium text-gray-800">{alert}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      <Section title="지난 미팅 블로커">
+        {lastMeeting ? (
+          <BlockerTagList items={lastMeeting.blockerKeywords} emptyText="지난 미팅 블로커가 없습니다." />
+        ) : (
+          <p className="text-xs text-gray-400">이전 미팅 데이터가 없습니다.</p>
+        )}
+      </Section>
+
+      <Section title="이번 미팅에서 다뤄볼 주제" isLast>
+        {data.recommendedTopics.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            {data.recommendedTopics.map((topic, index) => (
+              <div key={`${topic}-${index}`} className="flex items-start gap-2">
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#5F74FA]" />
+                <p className="text-xs leading-relaxed text-gray-800">{topic}</p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-gray-400">추천 주제가 아직 없습니다.</p>
+        )}
+      </Section>
+    </section>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  hint,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  hint: string;
+  color: {
+    bg: string;
+    border: string;
+    text: string;
+  };
+}) {
+  return (
+    <div
+      className="rounded-lg border px-3 py-2.5 text-center"
+      style={{ backgroundColor: color.bg, borderColor: color.border }}
+    >
+      <p className="text-[11px] text-gray-500">{label}</p>
+      <p className="mt-1 truncate text-lg font-semibold" style={{ color: color.text }}>
+        {value}
+      </p>
+      <p className="mt-0.5 truncate text-[11px] font-medium" style={{ color: color.text }}>
+        {hint}
+      </p>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+  isLast = false,
+}: {
+  title: string;
+  children: React.ReactNode;
+  isLast?: boolean;
+}) {
+  return (
+    <div className={`${isLast ? '' : 'mb-4'} border-t border-gray-100 pt-3.5`}>
+      <p className="mb-2.5 text-xs font-semibold text-gray-500">{title}</p>
+      {children}
+    </div>
+  );
+}

--- a/src/data/mockPreBriefing.ts
+++ b/src/data/mockPreBriefing.ts
@@ -1,0 +1,46 @@
+import type { PreBriefingData } from '@/types/meeting';
+
+export const MOCK_PRE_BRIEFING: PreBriefingData = {
+  meetingId: 10,
+  round: 5,
+  memberName: '김지수',
+  memberJobTitle: 'Frontend Engineer',
+  scheduledAt: '2026-06-05T15:00:00',
+  survey: {
+    submitted: true,
+    energyLevel: 3,
+    issues: ['QA 리소스', '배포 일정'],
+    desiredRoles: ['방향성 코칭', '리소스 지원'],
+    surveyScore: 68,
+  },
+  lastMeeting: {
+    safetyScore: 72,
+    safetyScoreChange: 8,
+    quadrant: 'STABLE',
+    honestyGap: {
+      direction: 'UNDERREPORT',
+      riskLevel: 'SAFE',
+    },
+    speechActAlerts: ['최근 3회 Vulnerability 발화 0건'],
+    blockerKeywords: ['QA 리소스', '배포 일정', 'API 문서'],
+  },
+  pendingPromises: [
+    {
+      promiseId: 1,
+      content: '테스트 체크리스트 작성',
+      dueDate: '2026-06-01',
+      overdue: true,
+    },
+    {
+      promiseId: 2,
+      content: 'Blocker Pyramid FE 완성',
+      dueDate: '2026-06-04',
+      overdue: false,
+    },
+  ],
+  recommendedTopics: [
+    '미이행 약속 2건 팔로업',
+    'QA 리소스 부족 해결 방안 논의',
+    'Vulnerability 발화 감소 배경 확인',
+  ],
+};

--- a/src/features/meeting/usePreBriefing.ts
+++ b/src/features/meeting/usePreBriefing.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchPreBriefing } from '@/api/meetings';
+import { MOCK_PRE_BRIEFING } from '@/data/mockPreBriefing';
+import type { PreBriefingData } from '@/types/meeting';
+
+export function usePreBriefing(meetingId: string | undefined) {
+  const [data, setData] = useState<PreBriefingData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  useEffect(() => {
+    if (!meetingId) {
+      setLoading(false);
+      return;
+    }
+
+    if (import.meta.env.VITE_USE_MOCK === 'true' && meetingId.startsWith('mock-')) {
+      setData(MOCK_PRE_BRIEFING);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchPreBriefing(meetingId)
+      .then((briefing) => {
+        if (!cancelled) setData(briefing);
+      })
+      .catch(() => {
+        if (!cancelled) setError('미팅 전 브리핑을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [meetingId, retryCount]);
+
+  const retry = useCallback(() => setRetryCount((count) => count + 1), []);
+
+  return { data, loading, error, retry };
+}

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -10,6 +10,8 @@ import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
 import AnalysisLoading from "@/components/loading/AnalysisLoading";
 import type { MeetingDetail } from "@/types/meeting";
 import LeaderReportView from "@/components/report/LeaderReportView";
+import PreBriefingCard from "@/components/meeting/PreBriefingCard";
+import { usePreBriefing } from "@/features/meeting/usePreBriefing";
 
 type LocalStatus = "pending" | "recording" | "uploading" | "analyzing" | "completed" | "error";
 
@@ -17,6 +19,7 @@ export default function MeetingDetailPage() {
   const { meetingId } = useParams<{ meetingId: string }>();
   const navigate = useNavigate();
   const { meeting, loading, error } = useMeetingDetail(meetingId);
+  const { data: briefing, loading: briefingLoading, error: briefingError, retry: retryBriefing } = usePreBriefing(meetingId);
   const recorder = useRecorder();
   const { upload } = useUploadRecording();
   const [showStart, setShowStart] = useState(false);
@@ -175,7 +178,33 @@ export default function MeetingDetailPage() {
           <MeetingHeader meeting={meeting} />
 
           {!recorder.isRecording && localStatus === "pending" && (
-            <div className="flex-1 flex flex-col items-center justify-center gap-3 px-8 pb-32">
+            <div className="flex-1 flex flex-col items-center justify-center gap-4 px-8 py-8 pb-32">
+              {briefingLoading && (
+                <div className="w-full max-w-[560px] rounded-xl border border-gray-100 bg-white px-6 py-5 shadow-sm">
+                  <div className="h-5 w-40 rounded bg-gray-100" />
+                  <div className="mt-4 grid grid-cols-3 gap-2.5">
+                    <div className="h-20 rounded-lg bg-gray-100" />
+                    <div className="h-20 rounded-lg bg-gray-100" />
+                    <div className="h-20 rounded-lg bg-gray-100" />
+                  </div>
+                  <div className="mt-4 h-16 rounded-lg bg-gray-100" />
+                </div>
+              )}
+              {!briefingLoading && briefing && <PreBriefingCard data={briefing} />}
+              {!briefingLoading && briefingError && (
+                <div className="w-full max-w-[560px] rounded-xl border border-red-100 bg-red-50 px-5 py-4 text-sm text-red-600">
+                  <div className="flex items-center justify-between gap-4">
+                    <span>{briefingError}</span>
+                    <button
+                      type="button"
+                      onClick={retryBriefing}
+                      className="shrink-0 rounded-lg bg-white px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-100"
+                    >
+                      다시 시도
+                    </button>
+                  </div>
+                </div>
+              )}
               {(() => {
                 const skipCheck = import.meta.env.VITE_SKIP_SURVEY_CHECK === 'true';
                 const surveyDone = skipCheck || meeting.surveySubmitted === true;

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -49,3 +49,38 @@ export interface MeetingListItem {
   durationSec: number | null;
   status: MeetingApiStatus;
 }
+
+export type MeetingQuadrant = 'STABLE' | 'SILENT_RISK' | 'EXPLICIT_RISK' | 'CONSERVATIVE';
+
+export interface PreBriefingData {
+  meetingId: number;
+  round: number;
+  memberName: string;
+  memberJobTitle: string;
+  scheduledAt: string;
+  survey: {
+    submitted: boolean;
+    energyLevel: number | null;
+    issues: string[];
+    desiredRoles: string[];
+    surveyScore: number | null;
+  };
+  lastMeeting: {
+    safetyScore: number;
+    safetyScoreChange: number | null;
+    quadrant: MeetingQuadrant | null;
+    honestyGap: {
+      direction: string;
+      riskLevel: string;
+    } | null;
+    speechActAlerts: string[];
+    blockerKeywords: string[];
+  } | null;
+  pendingPromises: {
+    promiseId: number;
+    content: string;
+    dueDate: string | null;
+    overdue: boolean;
+  }[];
+  recommendedTopics: string[];
+}

--- a/src/utils/blockerColors.ts
+++ b/src/utils/blockerColors.ts
@@ -1,0 +1,15 @@
+import type { BlockerPyramidColor } from '@/types/blocker';
+
+const BLOCKER_RANK_PALETTE: BlockerPyramidColor[] = [
+  { bg: '#FFECEF', text: '#FA5252', border: '#F8B4C0' },
+  { bg: '#FEFCE8', text: '#eb9925', border: '#FDE68A' },
+  { bg: '#EAF5FF', text: '#2563EB', border: '#BBD7FF' },
+  { bg: '#F4F4F5', text: '#52525B', border: '#D4D4D8' },
+];
+
+export function getBlockerRankColor(rank: number) {
+  if (rank === 1) return BLOCKER_RANK_PALETTE[0];
+  if (rank >= 2 && rank <= 4) return BLOCKER_RANK_PALETTE[1];
+  if (rank >= 5 && rank <= 7) return BLOCKER_RANK_PALETTE[2];
+  return BLOCKER_RANK_PALETTE[3];
+}


### PR DESCRIPTION
### **Summary**

Pre-Meeting Briefing Card추가


### **변경 파일 및 변경 사항**

`src/types/meeting.ts` 수정 
- PreBriefingData 타입 추가
- survey, lastMeeting, pendingPromises, recommendedTopics 구조 정의
MeetingQuadrant 타입 추가

`src/api/meetings.ts` 수정 
- fetchPreBriefing(meetingId) API 함수 추가
- /api/v1/meetings/{meetingId}/pre-briefing 호출 연결

`src/features/meeting/usePreBriefing.ts` 추가 
- 데이터 조회 훅 추가
- loading/error/retry 상태 처리
- VITE_USE_MOCK=true 및 mock- meetingId 사용 시 mock 데이터 활용해 화면 확인 가능
 
`src/data/mockPreBriefing.ts` 추가 
- 화면 확인용 mock 데이터 추가

`src/components/meeting/PreBriefingCard.tsx` 추가 
- prebriefing 카드 컴포넌트 추가

`src/pages/leader/MeetingDetailPage.tsx` 수정 
- 리더 미팅 상세 pending 상태에서 usePreBriefing 호출

`src/utils/blockerColors.ts` 추가
- 블로커 피라미드와 프리브리핑 카드가 공유하는 rank 기반 색상 유틸 추가
1위, 2-4위, 5-7위, 그 외 색상 규칙 분리

`src/components/charts/BlockerPyramid.tsx` 수정
- 기존 내부 블로커 색상 로직을 getBlockerRankColor 유틸 사용 방식으로 변경
