### PR TITLE
#feat: 녹음 업로드 실제 API 연동 및 서베이 완료 후 활성화

### DIFF
--- a/src/features/meeting/useUploadRecording.ts
+++ b/src/features/meeting/useUploadRecording.ts
@@ -13,17 +13,6 @@ export function useUploadRecording() {
       setError(msg);
       throw new Error(msg);
     }
-    // 테스트 조건, 백엔드 정상 연결 시 삭제
-    if (import.meta.env.VITE_USE_MOCK === 'true' && meetingId.startsWith('mock-')) {
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `recording-${meetingId}-${durationSec}s.webm`;
-      a.click();
-      URL.revokeObjectURL(url);
-      await new Promise((r) => setTimeout(r, 1500));
-      return;
-    }
     setIsUploading(true);
     setError(null);
     try {

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -10,6 +10,7 @@ import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
 import AnalysisLoading from "@/components/loading/AnalysisLoading";
 import type { MeetingDetail } from "@/types/meeting";
 import LeaderReportView from "@/components/report/LeaderReportView";
+import { useSurveyCompletion } from "@/features/meeting/useSurveyCompletion";
 
 type LocalStatus = "pending" | "recording" | "uploading" | "analyzing" | "completed" | "error";
 
@@ -24,11 +25,10 @@ export default function MeetingDetailPage() {
   const [localStatus, setLocalStatus] = useState<LocalStatus>("pending");
   const [uploadError, setUploadError] = useState<string | null>(null);
   const pendingUploadRef = useRef<{ blob: Blob; durationSec: number } | null>(null);
-  // 서베이 결과 적용 임시 테스트용 
-  // const { completed: surveyCompleted } = useSurveyCompletion(
-  //   meetingId,
-  //   !loading && !error && localStatus === "pending",
-  // );
+  const { completed: surveyCompleted } = useSurveyCompletion(
+    meetingId,
+    !loading && !error && localStatus === "pending",
+  );
 
   useEffect(() => {
     if (meeting?.status === "ANALYZING" || meeting?.status === "TRANSCRIBING") {
@@ -176,52 +176,30 @@ export default function MeetingDetailPage() {
 
           {!recorder.isRecording && localStatus === "pending" && (
             <div className="flex-1 flex flex-col items-center justify-center gap-3 px-8 pb-32">
-              {(() => {
-                const skipCheck = import.meta.env.VITE_SKIP_SURVEY_CHECK === 'true';
-                const surveyDone = skipCheck || meeting.surveySubmitted === true;
-                return (
+              <div className={`text-center text-sm ${surveyCompleted || meeting.surveySubmitted ? 'text-[#5F74FA]' : 'text-gray-400'}`}>
+                {surveyCompleted || meeting.surveySubmitted ? (
                   <>
-                    <div className={`text-center text-sm ${surveyDone ? 'text-[#5F74FA]' : 'text-gray-400'}`}>
-                      {surveyDone ? (
-                        <>
-                          <p className="font-medium">멤버의 사전 서베이가 완료되었습니다.</p>
-                          <p>미팅을 시작할 수 있습니다.</p>
-                        </>
-                      ) : (
-                        <>
-                          <p className="font-medium">멤버의 사전 서베이가 완료되지 않았습니다.</p>
-                          <p>멤버의 사전 서베이가 완료된 후 미팅을 시작할 수 있습니다.</p>
-                        </>
-                      )}
-                    </div>
-                    <button
-                      onClick={() => setShowStart(true)}
-                      disabled={!surveyDone}
-                      className={`px-8 py-3 rounded-full font-medium transition-all ${
-                        surveyDone
-                          ? 'text-white bg-[#5F74FA] hover:bg-[#4E62E6] shadow-lg shadow-[#5F74FA]/30'
-                          : 'text-gray-400 bg-gray-100 cursor-not-allowed'
-                      }`}
-                    >
-                      1on1 미팅 시작하기
-                    </button>
-                    {import.meta.env.VITE_SKIP_RECORDING === 'true' && (
-                      <label className="mt-2 cursor-pointer px-6 py-2 rounded-full border border-dashed border-gray-400 text-sm text-gray-500 hover:border-[#5F74FA] hover:text-[#5F74FA] transition-colors">
-                        [테스트] 파일 선택해서 업로드
-                        <input
-                          type="file"
-                          accept="audio/*,.webm"
-                          className="hidden"
-                          onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (file && meetingId) performUpload(meetingId, file, 0);
-                          }}
-                        />
-                      </label>
-                    )}
+                    <p className="font-medium">멤버의 사전 서베이가 완료되었습니다.</p>
+                    <p>미팅을 시작할 수 있습니다.</p>
                   </>
-                );
-              })()}
+                ) : (
+                  <>
+                    <p className="font-medium">멤버의 사전 서베이가 완료되지 않았습니다.</p>
+                    <p>멤버의 사전 서베이가 완료된 후 미팅을 시작할 수 있습니다.</p>
+                  </>
+                )}
+              </div>
+              <button
+                onClick={() => setShowStart(true)}
+                disabled={!surveyCompleted && !meeting.surveySubmitted}
+                className={`px-8 py-3 rounded-full font-medium transition-all ${
+                  surveyCompleted || meeting.surveySubmitted
+                    ? 'text-white bg-[#5F74FA] hover:bg-[#4E62E6] shadow-lg shadow-[#5F74FA]/30'
+                    : 'text-gray-400 bg-gray-100 cursor-not-allowed'
+                }`}
+              >
+                1on1 미팅 시작하기
+              </button>
             </div>
           )}
           {localStatus === "recording" && (

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -10,9 +10,9 @@ import RecordingFloatingBar from "@/components/ui/RecordingFloatingBar";
 import AnalysisLoading from "@/components/loading/AnalysisLoading";
 import type { MeetingDetail } from "@/types/meeting";
 import LeaderReportView from "@/components/report/LeaderReportView";
-import { useSurveyCompletion } from "@/features/meeting/useSurveyCompletion";
 import PreBriefingCard from "@/components/meeting/PreBriefingCard";
 import { usePreBriefing } from "@/features/meeting/usePreBriefing";
+import { useSurveyCompletion } from "@/features/meeting/useSurveyCompletion";
 
 type LocalStatus = "pending" | "recording" | "uploading" | "analyzing" | "completed" | "error";
 
@@ -171,6 +171,8 @@ export default function MeetingDetailPage() {
     );
   }
 
+  const surveyDone = surveyCompleted || meeting.surveySubmitted === true;
+
   return (
     <PageLayout>
       <div className="flex h-full">
@@ -205,8 +207,8 @@ export default function MeetingDetailPage() {
                   </div>
                 </div>
               )}
-              <div className={`text-center text-sm ${surveyCompleted || meeting.surveySubmitted ? 'text-[#5F74FA]' : 'text-gray-400'}`}>
-                {surveyCompleted || meeting.surveySubmitted ? (
+              <div className={`text-center text-sm ${surveyDone ? 'text-[#5F74FA]' : 'text-gray-400'}`}>
+                {surveyDone ? (
                   <>
                     <p className="font-medium">멤버의 사전 서베이가 완료되었습니다.</p>
                     <p>미팅을 시작할 수 있습니다.</p>
@@ -220,15 +222,29 @@ export default function MeetingDetailPage() {
               </div>
               <button
                 onClick={() => setShowStart(true)}
-                disabled={!surveyCompleted && !meeting.surveySubmitted}
+                disabled={!surveyDone}
                 className={`px-8 py-3 rounded-full font-medium transition-all ${
-                  surveyCompleted || meeting.surveySubmitted
+                  surveyDone
                     ? 'text-white bg-[#5F74FA] hover:bg-[#4E62E6] shadow-lg shadow-[#5F74FA]/30'
                     : 'text-gray-400 bg-gray-100 cursor-not-allowed'
                 }`}
               >
                 1on1 미팅 시작하기
               </button>
+              {import.meta.env.VITE_SKIP_RECORDING === 'true' && surveyDone && (
+                <label className="mt-2 cursor-pointer px-6 py-2 rounded-full border border-dashed border-gray-400 text-sm text-gray-500 hover:border-[#5F74FA] hover:text-[#5F74FA] transition-colors">
+                  [테스트] 파일 선택해서 업로드
+                  <input
+                    type="file"
+                    accept="audio/*,.webm"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file && meetingId) performUpload(meetingId, file, 0);
+                    }}
+                  />
+                </label>
+              )}
             </div>
           )}
           {localStatus === "recording" && (


### PR DESCRIPTION
## 변경 사항

### useUploadRecording.ts
- VITE_USE_MOCK 환경변수 분기 제거
- 환경변수 값에 관계없이 항상 실제 API(POST /api/v1/meetings/:id/recording)로 업로드

### MeetingDetailPage.tsx
- useSurveyCompletion 훅 활성화 (3초 폴링으로 서베이 완료 여부 실시간 감지)
- VITE_SKIP_SURVEY_CHECK 환경변수 우회 로직 제거
- 미팅 시작 버튼, [테스트] 파일 선택 업로드 버튼 모두 서베이 완료 후에만 활성화
- surveyCompleted(폴링) 또는 meeting.surveySubmitted(API 초기값) 중 하나라도 true이면 활성화

## 동작 방식

멤버가 서베이 미완료
  → 미팅 시작 버튼 및 파일 업로드 버튼 비활성화

멤버가 서베이 완료 (페이지 열린 이후라도)
  → useSurveyCompletion이 3초 이내 감지
  → 버튼 자동 활성화
  → 녹음 시작 또는 파일 직접 업로드 가능
  → 실제 API로 업로드

## 테스트 포인트
- [ ] 서베이 미완료 상태에서 미팅 상세 페이지 진입 → 버튼 비활성 확인
- [ ] 멤버가 서베이 제출 후 3초 이내 버튼 자동 활성화 확인
- [ ] VITE_SKIP_RECORDING=true 환경에서 서베이 완료 후 파일 업로드 버튼 노출 확인
- [ ] 미팅 종료 후 녹음 파일이 실제 서버로 업로드되는지 확인 (네트워크 탭)
