### PR TITLE
#FEAT: 리더 대시보드 멤버 발화 비율 리스트 백엔드 연동

### DIFF
--- a/src/api/teamDashboard.ts
+++ b/src/api/teamDashboard.ts
@@ -1,7 +1,7 @@
 import apiClient from './client';
 import type { ApiResponse } from './types';
 import type { BlockerPyramidData } from '@/types/blocker';
-import type { RadarDataPoint } from '@/types/analysis';
+import type { CommunicationBalance, RadarDataPoint } from '@/types/analysis';
 import type { TeamHealthScoreData } from '@/types/teamHealth';
 
 export async function fetchTeamDashboard(teamId: string): Promise<TeamHealthScoreData> {
@@ -21,6 +21,13 @@ export async function fetchBlockerPyramid(teamId: string): Promise<BlockerPyrami
 export async function fetchTeamQuadrant(teamId: string): Promise<RadarDataPoint[]> {
   const res = await apiClient.get<ApiResponse<RadarDataPoint[]>>(
     `/api/v1/teams/${teamId}/quadrant`,
+  );
+  return res.data.data;
+}
+
+export async function fetchTalkRatioRanking(teamId: string): Promise<CommunicationBalance[]> {
+  const res = await apiClient.get<ApiResponse<CommunicationBalance[]>>(
+    `/api/v1/teams/${teamId}/talk-ratio-ranking`,
   );
   return res.data.data;
 }

--- a/src/data/mockRadarData.ts
+++ b/src/data/mockRadarData.ts
@@ -58,10 +58,10 @@ export const MOCK_RADAR: RadarDataPoint[] = [
 ];
 
 export const MOCK_COMMS: CommunicationBalance[] = [
-  { memberId: 'm1', name: '다은', memberRatio: 15, leaderRatio: 85, status: '위험' },
-  { memberId: 'm2', name: '재민', memberRatio: 70, leaderRatio: 30, status: '적정' },
-  { memberId: 'm3', name: '민준', memberRatio: 55, leaderRatio: 45, status: '관찰' },
-  { memberId: 'm4', name: '서연', memberRatio: 40, leaderRatio: 60, status: '관찰' },
-  { memberId: 'm5', name: '지훈', memberRatio: 50, leaderRatio: 50, status: '적정' },
-  { memberId: 'm6', name: '유진', memberRatio: 52, leaderRatio: 48, status: '적정' },
+  { memberId: 1, name: '다은', memberRatio: 15, leaderRatio: 85, status: '위험' },
+  { memberId: 2, name: '재민', memberRatio: 70, leaderRatio: 30, status: '적정' },
+  { memberId: 3, name: '민준', memberRatio: 55, leaderRatio: 45, status: '관찰' },
+  { memberId: 4, name: '서연', memberRatio: 40, leaderRatio: 60, status: '관찰' },
+  { memberId: 5, name: '지훈', memberRatio: 50, leaderRatio: 50, status: '적정' },
+  { memberId: 6, name: '유진', memberRatio: 52, leaderRatio: 48, status: '적정' },
 ];

--- a/src/features/leader/useTalkRatioRanking.ts
+++ b/src/features/leader/useTalkRatioRanking.ts
@@ -1,10 +1,10 @@
-import { useState, useEffect } from 'react';
-import { fetchTeamQuadrant } from '@/api/teamDashboard';
-import type { RadarDataPoint } from '@/types/analysis';
-import { MOCK_RADAR } from '@/data/mockRadarData';
+import { useEffect, useState } from 'react';
+import { fetchTalkRatioRanking } from '@/api/teamDashboard';
+import { MOCK_COMMS } from '@/data/mockRadarData';
+import type { CommunicationBalance } from '@/types/analysis';
 
-export function useRadarData(teamId?: string) {
-  const [data, setData] = useState<RadarDataPoint[]>([]);
+export function useTalkRatioRanking(teamId?: string) {
+  const [data, setData] = useState<CommunicationBalance[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -17,7 +17,7 @@ export function useRadarData(teamId?: string) {
     }
 
     if (import.meta.env.VITE_USE_MOCK === 'true') {
-      setData(MOCK_RADAR);
+      setData(MOCK_COMMS);
       setLoading(false);
       setError(null);
       return;
@@ -26,23 +26,23 @@ export function useRadarData(teamId?: string) {
     let ignore = false;
     const resolvedTeamId = teamId;
 
-    async function loadRadarData() {
+    async function loadTalkRatioRanking() {
       setLoading(true);
       setError(null);
       try {
-        const result = await fetchTeamQuadrant(resolvedTeamId);
+        const result = await fetchTalkRatioRanking(resolvedTeamId);
         if (!ignore) setData(result);
       } catch {
         if (!ignore) {
           setData([]);
-          setError('사분면 레이더를 불러오지 못했습니다.');
+          setError('1on1 소통 균형 데이터를 불러오지 못했습니다.');
         }
       } finally {
         if (!ignore) setLoading(false);
       }
     }
 
-    loadRadarData();
+    loadTalkRatioRanking();
 
     return () => {
       ignore = true;

--- a/src/pages/leader/LeaderDashboard.tsx
+++ b/src/pages/leader/LeaderDashboard.tsx
@@ -9,6 +9,7 @@ import Badge from '@/components/ui/Badge';
 import { useRadarData } from '@/features/leader/useRadarData';
 import { useBlockerPyramid } from '@/features/leader/useBlockerPyramid';
 import { useTeamHealthScore } from '@/features/leader/useTeamHealthScore';
+import { useTalkRatioRanking } from '@/features/leader/useTalkRatioRanking';
 import { useAuthStore } from '@/stores/authStore';
 import type { CommunicationBalance } from '@/types/analysis';
 
@@ -70,7 +71,6 @@ export default function LeaderDashboard() {
   const teamId = useAuthStore((state) => state.user?.teamId);
   const {
     data: radarData,
-    comms,
     loading: radarLoading,
     error: radarError,
   } = useRadarData(teamId);
@@ -84,9 +84,14 @@ export default function LeaderDashboard() {
     loading: teamHealthLoading,
     error: teamHealthError,
   } = useTeamHealthScore(teamId);
+  const {
+    data: talkRatioRankings,
+    loading: talkRatioLoading,
+    error: talkRatioError,
+  } = useTalkRatioRanking(teamId);
   const [activeTab, setActiveTab] = useState<ChartTab>('radar');
   const radarItems = radarData ?? [];
-  const communicationItems = comms ?? [];
+  const communicationItems = talkRatioRankings ?? [];
   const blockerKeywords = blockerPyramid?.blockerKeywords ?? [];
   const actionFeedbackItems = useMemo(() => {
     return blockerPyramid?.actionPrescriptions ?? [];
@@ -233,11 +238,18 @@ export default function LeaderDashboard() {
                 1on1 소통 균형
               </p>
               <div className="flex flex-col">
-                {communicationItems.length > 0 ? (
+                {talkRatioLoading && (
+                  <p className="py-4 text-sm font-medium text-gray-400">1on1 소통 균형 데이터를 불러오는 중입니다.</p>
+                )}
+                {!talkRatioLoading && talkRatioError && (
+                  <ErrorState label="1on1 소통 균형" />
+                )}
+                {!talkRatioLoading && !talkRatioError && communicationItems.length > 0 ? (
                   communicationItems.map((item) => (
                     <CommRow key={item.memberId} item={item} />
                   ))
-                ) : (
+                ) : null}
+                {!talkRatioLoading && !talkRatioError && communicationItems.length === 0 && (
                   <p className="py-4 text-sm font-medium text-gray-400">아직 1on1 소통 균형 데이터가 없습니다.</p>
                 )}
               </div>

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -31,9 +31,9 @@ export interface RadarDataPoint {
 
 // 발화 비율 인터페이스
 export interface CommunicationBalance {
-  memberId: string;
+  memberId: number;
   name: string;
   memberRatio: number;
   leaderRatio: number;
-  status: '위험' | '적정' | '관찰';
+  status: '위험' | '관찰' | '적정';
 }


### PR DESCRIPTION
### **Summary**

- 리더 대시보드의 `1on1 소통 균형` 파트를 백엔드 API와 연결
- 기존에 `useRadarData` 내부에서 mock으로 관리하던 소통 균형 데이터를 별도 hook으로 분리
- 실제 BE 응답 스펙에 맞춰 `CommunicationBalance` 타입과 mock 데이터 정리

### **변경 파일**

- `src/types/analysis.ts`
  - `CommunicationBalance` 타입을 BE 응답에 맞게 수정
  - `memberId: string` → `memberId: number`
  - `status` 값을 `'위험' | '관찰' | '적정'` 기준으로 정리

- `src/api/teamDashboard.ts`
  - `fetchTalkRatioRanking(teamId)` API 함수 추가
  - 엔드포인트: `GET /api/v1/teams/{teamId}/talk-ratio-ranking`

- `src/features/leader/useTalkRatioRanking.ts`
  - 1on1 소통 균형 랭킹 조회 전용 hook 신규 생성
  - 실제 API 호출, mock 모드, loading/error/data 상태 처리

- `src/features/leader/useRadarData.ts`
  - `comms`, `MOCK_COMMS` 관련 로직 제거
  - Radar 데이터 조회만 담당하도록 책임 분리

- `src/pages/leader/LeaderDashboard.tsx`
  - `useTalkRatioRanking(teamId)` 연결
  - 기존 `useRadarData`의 `comms` 의존 제거
  - 1on1 소통 균형 카드에 API 데이터, 로딩, 에러, 빈 상태 반영

- `src/data/mockRadarData.ts`
  - `MOCK_COMMS`의 `memberId`를 실제 타입에 맞춰 number로 수정

