### PR TITLE
#fix: 리더 리포트 피드백 severity 대소문자 정규화

### DIFF
--- a/src/api/meetings.ts
+++ b/src/api/meetings.ts
@@ -55,6 +55,12 @@ function normalizeReportDate(value: unknown, fallback: string) {
   return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : fallback.slice(0, 10);
 }
 
+function normalizeSeverity(value: unknown): 'ERROR' | 'WARNING' | 'SUCCESS' {
+  const upper = typeof value === 'string' ? value.toUpperCase() : '';
+  if (upper === 'ERROR' || upper === 'WARNING' || upper === 'SUCCESS') return upper;
+  return 'WARNING';
+}
+
 function normalizeDurationSec(value: unknown) {
   const duration = typeof value === 'string' ? Number(value) : value;
   return typeof duration === 'number' && Number.isFinite(duration) && duration > 0
@@ -144,5 +150,12 @@ export async function fetchLeaderReport(meetingId: string): Promise<LeaderReport
   const res = await apiClient.get<ApiResponse<LeaderReport>>(
     `/api/v1/meetings/${meetingId}/leader-report`
   );
-  return res.data.data;
+  const data = res.data.data;
+  return {
+    ...data,
+    feedbacks: (data.feedbacks ?? []).map((fb) => ({
+      ...fb,
+      severity: normalizeSeverity((fb as unknown as Record<string, unknown>).severity),
+    })),
+  };
 }


### PR DESCRIPTION
변경 사항:
- src/api/meetings.ts에 normalizeSeverity 헬퍼 추가
- fetchLeaderReport 반환 시 feedbacks의 severity를 항상 대문자('ERROR' | 'WARNING' | 'SUCCESS')로 변환
- BE가 소문자/혼합 케이스로 severity를 내려보낼 경우에도 프론트 로직이 정상 동작하도록 처리

동작 방식:
- normalizeSeverity()는 문자열을 toUpperCase() 후 세 값 중 하나인지 확인
- 매핑 불가한 값은 'WARNING'으로 fallback
- fetchLeaderReport에서 data.feedbacks를 map하여 severity를 정규화한 후 반환

테스트 포인트:
- 리더 리포트 페이지 진입 시 피드백 카드의 severity 색상/아이콘이 정상 표시되는지 확인
- BE가 'error', 'Error', 'ERROR' 등 다양한 케이스로 내려도 동일하게 렌더링되는지 확인