### PR TITLE
#FEAT: 멤버 리포트 (미팅 분석 결과) 성과 타입 추가

### DIFF
--- a/src/data/mockMemberReport.ts
+++ b/src/data/mockMemberReport.ts
@@ -25,6 +25,24 @@ export const MOCK_MEMBER_REPORT: MemberReportData = {
       leaderQuote: '혼자 해결하지 않고 팀 전체를 끌어올리는 기여였습니다.',
       leaderName: '이준혁 팀장',
     },
+    {
+      careerEventId: 17,
+      type: 'GROWTH',
+      title: '장애 대응 역량 성장',
+      description: '로그 추적과 재현 시나리오 정리를 주도하며 운영 이슈 대응 속도를 높였습니다.',
+      impactMetric: '평균 대응 시간 -35%',
+      leaderQuote: '문제를 끝까지 파고드는 방식이 한 단계 더 탄탄해졌습니다.',
+      leaderName: '이준혁 팀장',
+    },
+    {
+      careerEventId: 18,
+      type: 'CONTRIBUTION',
+      title: '온보딩 문서 개선 기여',
+      description: '신규 입사자가 첫 배포까지 따라갈 수 있는 체크리스트와 예제를 보강했습니다.',
+      impactMetric: '온보딩 기간 -2일',
+      leaderQuote: '개인의 성과를 팀의 자산으로 바꾸는 좋은 기여였습니다.',
+      leaderName: '이준혁 팀장',
+    },
   ],
   leaderPromises: [
     {

--- a/src/pages/member/MemberReportPage.tsx
+++ b/src/pages/member/MemberReportPage.tsx
@@ -22,6 +22,16 @@ const achievementStyles: Record<MemberAchievementType, { keyword: string; card: 
     card: 'border-gray-200 bg-gray-50',
     text: 'text-blue-700',
   },
+  GROWTH: {
+    keyword: '성장',
+    card: 'border-gray-200 bg-gray-50',
+    text: 'text-violet-700',
+  },
+  CONTRIBUTION: {
+    keyword: '공헌',
+    card: 'border-gray-200 bg-gray-50',
+    text: 'text-amber-700',
+  },
 };
 
 const categoryTextStyles: Record<MemberPromiseCategory, string> = {

--- a/src/types/memberReport.ts
+++ b/src/types/memberReport.ts
@@ -1,4 +1,8 @@
-export type MemberAchievementType = 'ACHIEVEMENT' | 'PROPOSAL_ADOPTED';
+export type MemberAchievementType =
+  | 'ACHIEVEMENT'
+  | 'PROPOSAL_ADOPTED'
+  | 'GROWTH'
+  | 'CONTRIBUTION';
 export type MemberPromiseCategory = 'RESOURCE' | 'TEAM_BUILDING' | 'RECOGNITION' | 'PROCESS';
 export type MemberPromiseStatus = 'PENDING' | 'DONE';
 


### PR DESCRIPTION
### **작업 내용**

- 멤버 리포트 성과 타입에 `GROWTH`, `CONTRIBUTION` 추가
- 멤버 리포트 카드 스타일 매핑에 신규 타입 라벨/색상 추가
- 신규 타입 확인을 위한 멤버 리포트 목업 데이터 추가

### **변경 파일**

- `src/types/memberReport.ts`
- `src/pages/member/MemberReportPage.tsx`
- `src/data/mockMemberReport.ts`
