### PR TITLE
#FEAT: 리더 대시보드에 미이행 약속 리스트 추가 

### DIFF
--- a/src/api/promises.ts
+++ b/src/api/promises.ts
@@ -1,0 +1,11 @@
+import apiClient from './client';
+import type { ApiResponse } from './types';
+import type { OverduePromise } from '@/types/promise';
+
+export async function fetchOverduePromises(memberId?: number | string): Promise<OverduePromise[]> {
+  const res = await apiClient.get<ApiResponse<OverduePromise[]>>('/api/v1/promises/overdue', {
+    params: memberId ? { memberId } : undefined,
+  });
+
+  return res.data.data;
+}

--- a/src/data/mockPromises.ts
+++ b/src/data/mockPromises.ts
@@ -1,0 +1,31 @@
+import type { OverduePromise } from '@/types/promise';
+
+export const MOCK_OVERDUE_PROMISES: OverduePromise[] = [
+  {
+    promiseId: 5,
+    content: 'QA 리소스 이슈 에스컬레이션',
+    category: 'TEAM_BUILDING',
+    dueDate: '2026-05-12',
+    status: 'PENDING',
+    fromMeetingRound: 11,
+    memberName: '김민준',
+  },
+  {
+    promiseId: 4,
+    content: 'AWS 프로덕션 접근 권한 부여',
+    category: 'RESOURCE',
+    dueDate: '2026-05-15',
+    status: 'PENDING',
+    fromMeetingRound: 12,
+    memberName: '강다은',
+  },
+  {
+    promiseId: 6,
+    content: 'MSA 전환 성과 5분 발표 준비',
+    category: 'RECOGNITION',
+    dueDate: '2026-05-20',
+    status: 'MISSED',
+    fromMeetingRound: 10,
+    memberName: '이서연',
+  },
+];

--- a/src/features/leader/usePromises.ts
+++ b/src/features/leader/usePromises.ts
@@ -1,3 +1,64 @@
-export function usePromises(_teamId?: string) {
-  return { promises: [], loading: false };
+import { useEffect, useMemo, useState } from 'react';
+import { fetchOverduePromises } from '@/api/promises';
+import { MOCK_OVERDUE_PROMISES } from '@/data/mockPromises';
+import type { OverduePromise } from '@/types/promise';
+
+function sortByDueDate(promises: OverduePromise[]) {
+  return [...promises].sort((a, b) => {
+    const aTime = new Date(a.dueDate).getTime();
+    const bTime = new Date(b.dueDate).getTime();
+    return aTime - bTime;
+  });
+}
+
+export function usePromises(teamId?: string) {
+  const [promises, setPromises] = useState<OverduePromise[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!teamId) {
+      setPromises([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (import.meta.env.VITE_USE_MOCK === 'true') {
+      setPromises(MOCK_OVERDUE_PROMISES);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let ignore = false;
+
+    async function loadPromises() {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchOverduePromises();
+        if (!ignore) setPromises(result);
+      } catch {
+        if (!ignore) {
+          setPromises([]);
+          setError('미이행 약속 목록을 불러오지 못했습니다.');
+        }
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+
+    loadPromises();
+
+    return () => {
+      ignore = true;
+    };
+  }, [teamId]);
+
+  const pendingPromises = useMemo(() => {
+    return sortByDueDate(promises.filter((promise) => promise.status !== 'DONE'));
+  }, [promises]);
+
+  return { promises: pendingPromises, loading, error };
 }

--- a/src/pages/leader/LeaderDashboard.tsx
+++ b/src/pages/leader/LeaderDashboard.tsx
@@ -10,8 +10,10 @@ import { useRadarData } from '@/features/leader/useRadarData';
 import { useBlockerPyramid } from '@/features/leader/useBlockerPyramid';
 import { useTeamHealthScore } from '@/features/leader/useTeamHealthScore';
 import { useTalkRatioRanking } from '@/features/leader/useTalkRatioRanking';
+import { usePromises } from '@/features/leader/usePromises';
 import { useAuthStore } from '@/stores/authStore';
 import type { CommunicationBalance } from '@/types/analysis';
+import type { OverduePromise } from '@/types/promise';
 
 // ── Talk Ratio Bar ─────────────────────────────────────────────────────────────
 
@@ -65,6 +67,28 @@ function ErrorState({ label }: { label: string }) {
   );
 }
 
+function formatDueDate(date: string) {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return date;
+
+  return parsed.toLocaleDateString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function PromiseRow({ promise }: { promise: OverduePromise }) {
+  return (
+    <div className="border-t border-gray-100 py-3 first:border-t-0 first:pt-0 last:pb-0">
+      <p className="text-sm text-gray-950">
+        <span>{promise.memberName}</span>님과의 약속
+      </p>
+      <p className="mt-1 text-sm font-bold leading-5 text-gray-950">{promise.content}</p>
+      <p className="mt-1 text-xs font-medium text-gray-400">마감일 {formatDueDate(promise.dueDate)}</p>
+    </div>
+  );
+}
+
 type ChartTab = 'radar' | 'blocker';
 
 export default function LeaderDashboard() {
@@ -89,6 +113,11 @@ export default function LeaderDashboard() {
     loading: talkRatioLoading,
     error: talkRatioError,
   } = useTalkRatioRanking(teamId);
+  const {
+    promises,
+    loading: promisesLoading,
+    error: promisesError,
+  } = usePromises(teamId);
   const [activeTab, setActiveTab] = useState<ChartTab>('radar');
   const radarItems = radarData ?? [];
   const communicationItems = talkRatioRankings ?? [];
@@ -251,6 +280,28 @@ export default function LeaderDashboard() {
                 ) : null}
                 {!talkRatioLoading && !talkRatioError && communicationItems.length === 0 && (
                   <p className="py-4 text-sm font-medium text-gray-400">아직 1on1 소통 균형 데이터가 없습니다.</p>
+                )}
+              </div>
+            </Card>
+
+            <Card className="p-4">
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+                미이행 약속
+              </p>
+              <div className="flex flex-col">
+                {promisesLoading && (
+                  <p className="py-4 text-sm font-medium text-gray-400">미이행 약속을 불러오는 중입니다.</p>
+                )}
+                {!promisesLoading && promisesError && (
+                  <p className="text-sm font-medium text-gray-400">{promisesError}</p>
+                )}
+                {!promisesLoading && !promisesError && promises.length > 0 && (
+                  promises.map((promise) => (
+                    <PromiseRow key={promise.promiseId} promise={promise} />
+                  ))
+                )}
+                {!promisesLoading && !promisesError && promises.length === 0 && (
+                  <p className="py-4 text-sm font-medium text-gray-400">아직 미이행 약속이 없습니다.</p>
                 )}
               </div>
             </Card>

--- a/src/types/promise.ts
+++ b/src/types/promise.ts
@@ -1,5 +1,7 @@
 export type PromiseStatus = 'pending' | 'done' | 'missed'
 export type PromiseOwner = 'leader' | 'member'
+export type LeaderPromiseStatus = 'PENDING' | 'DONE' | 'MISSED'
+export type LeaderPromiseCategory = 'RESOURCE' | 'TEAM_BUILDING' | 'RECOGNITION' | 'PROCESS'
 
 export interface MeetingPromise {
   id: string
@@ -8,4 +10,14 @@ export interface MeetingPromise {
   content: string
   dueDate?: string
   status: PromiseStatus
+}
+
+export interface OverduePromise {
+  promiseId: number
+  content: string
+  category: LeaderPromiseCategory
+  dueDate: string
+  status: LeaderPromiseStatus
+  fromMeetingRound: number
+  memberName: string
 }


### PR DESCRIPTION
### **작업 내용**
- 리더 대시보드의 1on1 소통 균형 섹션 아래에 미이행 약속 리스트를 추가
- `/api/v1/promises/overdue` API를 호출하는 약속 조회 API 함수와 `usePromises` 훅 구현
- mock 모드에서 확인할 수 있도록 미이행 약속 mock 데이터를 추가

### **세부 사항**
- 미이행 약속은 마감일 임박순으로 정렬
- 멤버 이름, 약속 내용, 마감 날짜 내용 표시 
