### PR TITLE
feat/design: 리더 리포트 - 맞춤 피드백 탭 우선 노출 및 UI 개선

### DIFF
--- a/src/components/report/FeedbackSection.tsx
+++ b/src/components/report/FeedbackSection.tsx
@@ -83,7 +83,7 @@ export default function FeedbackSection({ items }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
-        AI 피드백
+        맞춤 피드백
       </h3>
       <div className="flex flex-col gap-2">
         {sorted.map((item) => (

--- a/src/components/report/FeedbackSection.tsx
+++ b/src/components/report/FeedbackSection.tsx
@@ -41,9 +41,12 @@ function FeedbackItem({ item }: { item: Feedback }) {
         className={`w-full flex items-center justify-between px-4 py-3 text-left ${config.bg} hover:brightness-95 transition-all`}
         onClick={() => setExpanded((v) => !v)}
       >
-        <div className="flex items-center gap-2">
-          <span>{config.icon}</span>
-          <span className="text-sm font-medium text-gray-800">{item.title}</span>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="flex-shrink-0">{config.icon}</span>
+          <div className="flex flex-col items-start min-w-0">
+            <span className="text-[16px] font-normal text-gray-800">{item.actionGuide}</span>
+            <span className="text-sm text-gray-400">{item.title}</span>
+          </div>
         </div>
         <span className="text-gray-400 text-sm flex-shrink-0 ml-2">
           {expanded ? '▲' : '▼'}
@@ -52,18 +55,14 @@ function FeedbackItem({ item }: { item: Feedback }) {
       {expanded && (
         <div className="px-4 py-3 flex flex-col gap-3 border-t border-gray-100 bg-white">
           <div>
-            <p className="text-xs font-semibold text-gray-400 mb-1">근거 발화</p>
-            <p className="text-xs text-gray-600 italic bg-gray-50 rounded px-3 py-2 leading-relaxed">
+            <p className="text-sm font-semibold text-gray-400 mb-1">근거 발화</p>
+            <p className="text-sm text-gray-600 italic bg-gray-50 rounded px-3 py-2 leading-relaxed">
               {item.evidenceQuote}
             </p>
           </div>
           <div>
-            <p className="text-xs font-semibold text-gray-400 mb-1">데이터 요약</p>
-            <p className="text-xs text-gray-600 leading-relaxed">{item.dataSummary}</p>
-          </div>
-          <div>
-            <p className="text-xs font-semibold text-[#5F74FA] mb-1">액션 가이드</p>
-            <p className="text-xs text-gray-700 leading-relaxed">{item.actionGuide}</p>
+            <p className="text-sm font-semibold text-gray-400 mb-1">데이터 요약</p>
+            <p className="text-sm text-gray-600 leading-relaxed">{item.dataSummary}</p>
           </div>
         </div>
       )}

--- a/src/components/report/FeedbackSection.tsx
+++ b/src/components/report/FeedbackSection.tsx
@@ -44,8 +44,8 @@ function FeedbackItem({ item }: { item: Feedback }) {
         <div className="flex items-center gap-2 min-w-0">
           <span className="flex-shrink-0">{config.icon}</span>
           <div className="flex flex-col items-start min-w-0">
-            <span className="text-[16px] font-normal text-gray-800">{item.actionGuide}</span>
-            <span className="text-sm text-gray-400">{item.title}</span>
+            <span className="text-[16px] font-medium text-gray-800">{item.actionGuide}</span>
+            <span className="text-[12px] font-light text-gray-400">{item.title}</span>
           </div>
         </div>
         <span className="text-gray-400 text-sm flex-shrink-0 ml-2">

--- a/src/components/report/LeaderReportView.tsx
+++ b/src/components/report/LeaderReportView.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 export default function LeaderReportView({ meetingId }: Props) {
   const { report, loading, error, retry } = useLeaderReport(meetingId);
-  const [activeTab, setActiveTab] = useState<ReportTab>('analysis');
+  const [activeTab, setActiveTab] = useState<ReportTab>('feedback');
   const actionPlan = useActionPlan(report?.nextActionPlans ?? EMPTY_ACTION_PLANS);
 
   if (loading) {
@@ -49,7 +49,7 @@ export default function LeaderReportView({ meetingId }: Props) {
     <div className="flex flex-col flex-1 min-h-0">
       {/* Tab bar */}
       <div className="flex border-b border-gray-200 px-8">
-        {(['analysis', 'feedback'] as ReportTab[]).map((tab) => {
+        {(['feedback', 'analysis'] as ReportTab[]).map((tab) => {
           const label = tab === 'analysis' ? '미팅 분석' : '리더 맞춤 피드백';
           return (
             <button

--- a/src/components/report/PromisesSection.tsx
+++ b/src/components/report/PromisesSection.tsx
@@ -21,13 +21,16 @@ export default function PromisesSection({ data }: Props) {
         {data.previous.length > 0 && (
           <div className="rounded-xl border border-gray-200 overflow-hidden">
             <div className="px-4 py-2 bg-gray-50 border-b border-gray-200">
-              <p className="text-xs font-semibold text-gray-500">이전 약속</p>
+              <p className="text-sm font-semibold text-gray-500">이전 약속</p>
             </div>
             {data.previous.map((p, idx) => (
               <div key={p.promiseId}>
                 <div className="flex items-center gap-3 px-4 py-3">
                   <span className="text-base flex-shrink-0">
-                    {p.status === 'DONE' ? '✅' : '❌'}
+                    {p.status === 'DONE'
+                      ? <span className="text-green-500 font-bold">✓</span>
+                      : <span className="text-red-400 font-bold">✕</span>
+                    }
                   </span>
                   <span
                     className={`text-sm flex-1 ${
@@ -58,7 +61,7 @@ export default function PromisesSection({ data }: Props) {
         {data.new.length > 0 && (
           <div className="rounded-xl border border-gray-200 overflow-hidden">
             <div className="px-4 py-2 bg-gray-50 border-b border-gray-200">
-              <p className="text-xs font-semibold text-gray-500">새 약속</p>
+              <p className="text-sm font-semibold text-gray-500">새 약속</p>
             </div>
             {data.new.map((p, idx) => (
               <div key={p.promiseId}>

--- a/src/features/meeting/useActionPlan.ts
+++ b/src/features/meeting/useActionPlan.ts
@@ -14,9 +14,17 @@ export function useActionPlan(items: ActionPlan[]) {
   }, [items]);
 
   const toggle = async (planId: number, currentlyDone: boolean) => {
-    if (currentlyDone) return;
-    setCompleted((prev) => new Set([...prev, planId]));
     setErrorId(null);
+    if (currentlyDone) {
+      setCompleted((prev) => {
+        const next = new Set(prev);
+        next.delete(planId);
+        return next;
+      });
+      // TODO: await uncompleteActionPlan(planId) — BE 엔드포인트 추가 후 연결
+      return;
+    }
+    setCompleted((prev) => new Set([...prev, planId]));
     if (!isMock) {
       try {
         await completeActionPlan(planId);


### PR DESCRIPTION
변경 사항:
- LeaderReportView: 탭 순서를 '미팅 분석 → 리더 맞춤 피드백'에서 '리더 맞춤 피드백 → 미팅 분석'으로 변경, 기본 활성 탭도 feedback으로 전환
- FeedbackSection: 토글 헤더에 actionGuide(font-medium, 16px)를 우선 표시하고 title(font-light, 12px)을 부제목으로 배치, 섹션 제목을 '맞춤 피드백'으로 변경, 본문 텍스트 크기 xs → sm 증가
- PromisesSection: 이행 상태 이모지(✅/❌)를 배경 없는 텍스트 기호(✓/✕)로 교체, 섹션 헤더 폰트 xs → sm 증가
- useActionPlan: 체크된 Action Plan을 다시 클릭하면 체크 해제되도록 toggle 로직 수정 (BE 연결은 TODO로 남김)

동작 방식:
- 리더가 리포트 페이지 진입 시 '리더 맞춤 피드백' 탭이 먼저 보임
- 피드백 아이템의 헤더에서 actionGuide를 먼저 읽고, 토글 시 근거 발화/데이터 요약 확인
- 약속 이행 여부는 ✓(초록)/✕(빨강) 텍스트 기호로 표시
- Action Plan 체크박스는 체크/체크 해제 모두 가능 (BE 미이행 취소 엔드포인트 추가 전까지 클라이언트 UI만 반영)

테스트 포인트:
- [ ] /leader/meeting/:id 진입 시 '리더 맞춤 피드백' 탭이 기본으로 활성화되는지 확인
- [ ] FeedbackSection 토글 헤더에 actionGuide → title 순으로 표시되는지 확인
- [ ] 피드백 아이템 클릭 시 근거 발화, 데이터 요약 섹션 펼쳐지는지 확인
- [ ] PromisesSection에서 DONE/UNDONE 약속에 ✓/✕가 각각 올바른 색상으로 표시되는지 확인
- [ ] Action Plan 체크 후 다시 클릭하면 체크 해제되는지 확인
- [ ] '미팅 분석' 탭 전환이 정상 동작하는지 확인 (회귀 없음)
