### PR TITLE
design: SurveyForm VDI 문항 레이블을 BE 스펙에 맞게 교체

### DIFF
--- a/src/api/actionPlans.ts
+++ b/src/api/actionPlans.ts
@@ -4,3 +4,7 @@ import type { ApiResponse } from './types';
 export async function completeActionPlan(planId: number): Promise<void> {
   await apiClient.patch<ApiResponse<null>>(`/api/v1/action-plans/${planId}/complete`);
 }
+
+export async function uncompleteActionPlan(planId: number): Promise<void> {
+  await apiClient.patch<ApiResponse<null>>(`/api/v1/action-plans/${planId}/incomplete`);
+}

--- a/src/components/report/FeedbackSection.tsx
+++ b/src/components/report/FeedbackSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Feedback } from '@/types/report';
+import { mapFeedbackTitle, replaceTermsInText } from '@/constants/feedbackTermMap';
 
 const SEVERITY_ORDER: Record<Feedback['severity'], number> = {
   ERROR: 0,
@@ -44,8 +45,8 @@ function FeedbackItem({ item }: { item: Feedback }) {
         <div className="flex items-center gap-2 min-w-0">
           <span className="flex-shrink-0">{config.icon}</span>
           <div className="flex flex-col items-start min-w-0">
-            <span className="text-[16px] font-medium text-gray-800">{item.actionGuide}</span>
-            <span className="text-[12px] font-light text-gray-400">{item.title}</span>
+            <span className="text-[16px] font-medium text-gray-800">{replaceTermsInText(item.actionGuide)}</span>
+            <span className="text-[12px] font-light text-gray-400">{mapFeedbackTitle(item.title)}</span>
           </div>
         </div>
         <span className="text-gray-400 text-sm flex-shrink-0 ml-2">

--- a/src/components/report/FeedbackSection.tsx
+++ b/src/components/report/FeedbackSection.tsx
@@ -82,7 +82,7 @@ export default function FeedbackSection({ items }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
-        맞춤 피드백
+        상세 피드백
       </h3>
       <div className="flex flex-col gap-2">
         {sorted.map((item) => (

--- a/src/components/report/SpeechActsSection.tsx
+++ b/src/components/report/SpeechActsSection.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import type { SpeechActs, SpeechActItem } from '@/types/report';
 
 const ACT_LABELS: Record<keyof SpeechActs, string> = {
-  vulnerability: '취약성 표현 (Vulnerability)',
-  constructiveDissent: '건설적 반론 (Constructive Dissent)',
-  initiative: '주도성 (Initiative)',
+  vulnerability: '솔직한 표현 (Vulnerability)',
+  constructiveDissent: '건설적 의견 (Constructive Dissent)',
+  initiative: '자발적 제안 (Initiative)',
 };
 
 function ChangeRateBadge({ rate }: { rate: number }) {

--- a/src/components/survey/SurveyForm.tsx
+++ b/src/components/survey/SurveyForm.tsx
@@ -7,15 +7,15 @@ import Card from '@/components/ui/Card';
 const vdiQuestions = [
   {
     key: 'vulnerabilityLevel' as const,
-    label: 'Q1. 오늘 미팅에서 어려운 점이나 고민을 편하게 꺼낼 수 있으신가요?',
+    label: 'Q1. 나는 이번 미팅에서 어려움/실수를 솔직히 말할 수 있을 것 같다',
   },
   {
     key: 'dissentLevel' as const,
-    label: 'Q2. 다르게 생각하는 부분이 있다면 자유롭게 말씀드릴 수 있으신가요?',
+    label: 'Q2. 나는 리더 의견에 동의하지 않으면 말할 수 있다',
   },
   {
     key: 'initiativeLevel' as const,
-    label: 'Q3. 개선하고 싶거나 시도해보고 싶은 아이디어가 있다면 먼저 꺼낼 수 있으신가요?',
+    label: 'Q3. 나는 이번 미팅에서 먼저 의견을 제안할 것이다',
   },
 ];
 

--- a/src/constants/feedbackTermMap.ts
+++ b/src/constants/feedbackTermMap.ts
@@ -1,0 +1,17 @@
+export const FEEDBACK_TERM_MAP: Record<string, string> = {
+  'Vulnerability 부족': '솔직한 표현이 적었어요',
+  '더 많은 Vulnerability 발화를': '솔직하게 표현',
+  'Constructive Dissent 부족': '건설적 의견이 적었어요',
+  '적극적인 Initiative 발휘': '자발적 제안이 활발했어요',
+};
+
+export function mapFeedbackTitle(title: string): string {
+  return FEEDBACK_TERM_MAP[title] ?? title;
+}
+
+export function replaceTermsInText(text: string): string {
+  return Object.entries(FEEDBACK_TERM_MAP).reduce(
+    (result, [from, to]) => result.split(from).join(to),
+    text
+  );
+}

--- a/src/features/meeting/useActionPlan.ts
+++ b/src/features/meeting/useActionPlan.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { completeActionPlan } from '@/api/actionPlans';
+import { completeActionPlan, uncompleteActionPlan } from '@/api/actionPlans';
 import type { ActionPlan } from '@/types/report';
 
 export function useActionPlan(items: ActionPlan[]) {
@@ -21,7 +21,14 @@ export function useActionPlan(items: ActionPlan[]) {
         next.delete(planId);
         return next;
       });
-      // TODO: await uncompleteActionPlan(planId) — BE 엔드포인트 추가 후 연결
+      if (!isMock) {
+        try {
+          await uncompleteActionPlan(planId);
+        } catch {
+          setCompleted((prev) => new Set([...prev, planId]));
+          setErrorId(planId);
+        }
+      }
       return;
     }
     setCompleted((prev) => new Set([...prev, planId]));

--- a/src/pages/leader/MeetingsPage.tsx
+++ b/src/pages/leader/MeetingsPage.tsx
@@ -243,9 +243,6 @@ export default function MeetingsPage({
                   <h3 className="text-lg font-semibold text-gray-900">1on1 멤버</h3>
                   <p className="text-sm text-gray-500">이번 달에 만나야 할 멤버를 확인해보세요.</p>
                 </div>
-                <button className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50">
-                  + 추가
-                </button>
               </div>
 
               {uniqueMembers.length === 0 ? (


### PR DESCRIPTION
변경 사항:
- SurveyForm의 Q1~Q3 문항 레이블을 BE VDI 스펙에 맞게 수정
  - Q1 (Vulnerability): "나는 이번 미팅에서 어려움/실수를 솔직히 말할 수 있을 것 같다"
  - Q2 (Dissent): "나는 리더 의견에 동의하지 않으면 말할 수 있다"
  - Q3 (Initiative): "나는 이번 미팅에서 먼저 의견을 제안할 것이다"
- scores 구조(vulnerabilityLevel / dissentLevel / initiativeLevel)는 이미 BE 기대 형식과 일치하여 변경 없음

동작 방식:
- BE의 surveyScore 계산식(V×8 + D×7 + I×5)에 맞는 문항으로 교체
- surveyScore null → honestyGap null → 리더 리포트 오류 방지

테스트 포인트:
- [ ] SurveyPage 진입 시 3개 문항이 올바른 레이블로 렌더링되는지 확인
- [ ] 각 문항 1~5점 선택 후 제출 시 BE에 scores 정상 전달 확인
- [ ] 리더 리포트에서 honestyGap 값이 null이 아닌 정상 수치로 표시되는지 확인
