### PR TITLE
feat: 실시간 발화 비율 감지 + 아두이노 LED 연동 (FE)

### DIFF
--- a/src/components/iot/IotPanel.tsx
+++ b/src/components/iot/IotPanel.tsx
@@ -1,16 +1,13 @@
 import { useEffect } from 'react';
-import { useTalkRatioStream } from '@/features/meeting/useTalkRatioStream';
 import { useArduinoSerial } from '@/features/meeting/useArduinoSerial';
 
 interface Props {
-  meetingId: string | undefined;
+  ratio: { leaderRatio: number; memberRatio: number } | null;
   isRecording?: boolean;
 }
 
-export default function IotPanel({ meetingId, isRecording }: Props) {
-  const meetingIdNum = meetingId ? Number(meetingId) : null;
-  const ratio = useTalkRatioStream(isRecording ? meetingIdNum : null);
-  const { connected, connect, send } = useArduinoSerial();
+export default function IotPanel({ ratio, isRecording }: Props) {
+  const { connected, connect, send, disconnect } = useArduinoSerial();
 
   const leaderRatio = ratio?.leaderRatio ?? 0;
 
@@ -52,10 +49,10 @@ export default function IotPanel({ meetingId, isRecording }: Props) {
       )}
 
       <button
-        onClick={connected ? undefined : connect}
+        onClick={connected ? disconnect : connect}
         className="text-xs text-gray-400 hover:text-gray-600 underline"
       >
-        {connected ? 'LED 연결됨' : 'LED 연결'}
+        {connected ? 'LED 연결 해제' : 'LED 연결'}
       </button>
     </div>
   );

--- a/src/components/iot/IotPanel.tsx
+++ b/src/components/iot/IotPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
-import { useIoTTalkRatio } from '@/features/meeting/useIoTTalkRatio';
+import { useTalkRatioStream } from '@/features/meeting/useTalkRatioStream';
+import { useArduinoSerial } from '@/features/meeting/useArduinoSerial';
 
 interface Props {
   meetingId: string | undefined;
@@ -7,57 +8,54 @@ interface Props {
 }
 
 export default function IotPanel({ meetingId, isRecording }: Props) {
-  const { state, connectSerial, disconnectSerial, startVAD, stop } = useIoTTalkRatio(meetingId);
+  const meetingIdNum = meetingId ? Number(meetingId) : null;
+  const ratio = useTalkRatioStream(isRecording ? meetingIdNum : null);
+  const { connected, connect, send } = useArduinoSerial();
 
-  // 녹음 시작 시 자동으로 VAD 측정 시작
+  const leaderRatio = ratio?.leaderRatio ?? 0;
+
   useEffect(() => {
-    if (isRecording) {
-      startVAD();
-    } else {
-      stop();
-    }
-  }, [isRecording]);
+    if (!ratio || !isRecording) return;
+    send(ratio.leaderRatio >= 70 ? 'R' : 'G');
+  }, [ratio, isRecording, send]);
 
   return (
     <div className="border border-gray-200 rounded-xl p-4 bg-white space-y-3">
       <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">발화 비율</p>
 
-      {/* LED 상태 + 비율 */}
       <div className="flex items-center gap-2">
         <div
           className={`w-3 h-3 rounded-full flex-shrink-0 ${
             isRecording
-              ? state.ledColor === 'RED' ? 'bg-red-500 animate-pulse' : 'bg-green-500'
+              ? leaderRatio >= 70 ? 'bg-red-500 animate-pulse' : 'bg-green-500'
               : 'bg-gray-300'
           }`}
         />
         <span className="text-sm text-gray-700">
-          리더 <span className="font-semibold">{state.leaderRatio}%</span>
+          리더 <span className="font-semibold">{leaderRatio}%</span>
           {' / '}
-          멤버 <span className="font-semibold">{100 - state.leaderRatio}%</span>
+          멤버 <span className="font-semibold">{ratio?.memberRatio ?? 0}%</span>
         </span>
       </div>
 
-      {/* 진행바 */}
       <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
         <div
           className={`h-full rounded-full transition-all duration-1000 ${
-            state.leaderRatio >= 70 ? 'bg-red-400' : 'bg-teal-400'
+            leaderRatio >= 70 ? 'bg-red-400' : 'bg-teal-400'
           }`}
-          style={{ width: `${state.leaderRatio}%` }}
+          style={{ width: `${leaderRatio}%` }}
         />
       </div>
 
-      {state.leaderRatio >= 70 && isRecording && (
+      {leaderRatio >= 70 && isRecording && (
         <p className="text-xs text-red-500">리더 발화 비율이 높습니다 (권장 40%)</p>
       )}
 
-      {/* LED 연결 버튼 — 작게 하단에 */}
       <button
-        onClick={state.connected ? disconnectSerial : connectSerial}
+        onClick={connected ? undefined : connect}
         className="text-xs text-gray-400 hover:text-gray-600 underline"
       >
-        {state.connected ? 'LED 연결 해제' : 'LED 연결'}
+        {connected ? 'LED 연결됨' : 'LED 연결'}
       </button>
     </div>
   );

--- a/src/components/meeting/TalkRatioBadge.tsx
+++ b/src/components/meeting/TalkRatioBadge.tsx
@@ -1,0 +1,29 @@
+interface Props {
+  leaderRatio: number | null;
+  calibrationState: 'idle' | 'leader' | 'member' | 'done';
+}
+
+export default function TalkRatioBadge({ leaderRatio, calibrationState }: Props) {
+  if (calibrationState === 'leader') {
+    return (
+      <div className="rounded-full bg-slate-100 px-4 py-2 text-sm text-slate-600">
+        리더님 먼저 인사해 주세요...
+      </div>
+    );
+  }
+  if (calibrationState === 'member') {
+    return (
+      <div className="rounded-full bg-slate-100 px-4 py-2 text-sm text-slate-600">
+        멤버님 이어서 인사해 주세요...
+      </div>
+    );
+  }
+  if (calibrationState !== 'done' || leaderRatio === null) return null;
+
+  const isHigh = leaderRatio >= 70;
+  return (
+    <div className={`rounded-full px-4 py-2 text-sm font-bold text-white ${isHigh ? 'bg-red-500' : 'bg-green-500'}`}>
+      리더 발화 {leaderRatio}%
+    </div>
+  );
+}

--- a/src/features/meeting/useArduinoSerial.ts
+++ b/src/features/meeting/useArduinoSerial.ts
@@ -1,7 +1,8 @@
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 
 export function useArduinoSerial() {
   const [connected, setConnected] = useState(false);
+  const portRef = useRef<any | null>(null);
   const writerRef = useRef<WritableStreamDefaultWriter<Uint8Array> | null>(null);
 
   const connect = useCallback(async () => {
@@ -12,6 +13,7 @@ export function useArduinoSerial() {
     try {
       const port = await navigator.serial.requestPort();
       await port.open({ baudRate: 9600 });
+      portRef.current = port;
       writerRef.current = port.writable.getWriter();
       setConnected(true);
     } catch {
@@ -26,5 +28,27 @@ export function useArduinoSerial() {
     } catch { /* 연결 끊김 무시 */ }
   }, []);
 
-  return { connected, connect, send };
+  const disconnect = useCallback(async () => {
+    try {
+      if (writerRef.current) {
+        await writerRef.current.close();
+        writerRef.current = null;
+      }
+      if (portRef.current) {
+        await portRef.current.close();
+        portRef.current = null;
+      }
+    } catch { /* ignore */ }
+    setConnected(false);
+  }, []);
+
+  // 언마운트 시 포트 정리
+  useEffect(() => {
+    return () => {
+      if (writerRef.current) writerRef.current.releaseLock();
+      if (portRef.current) portRef.current.close().catch(() => {});
+    };
+  }, []);
+
+  return { connected, connect, send, disconnect };
 }

--- a/src/features/meeting/useArduinoSerial.ts
+++ b/src/features/meeting/useArduinoSerial.ts
@@ -1,0 +1,30 @@
+import { useRef, useState, useCallback } from 'react';
+
+export function useArduinoSerial() {
+  const [connected, setConnected] = useState(false);
+  const writerRef = useRef<WritableStreamDefaultWriter<Uint8Array> | null>(null);
+
+  const connect = useCallback(async () => {
+    if (!('serial' in navigator)) {
+      alert('Web Serial API는 Chrome/Edge 브라우저에서만 지원됩니다.');
+      return;
+    }
+    try {
+      const port = await navigator.serial.requestPort();
+      await port.open({ baudRate: 9600 });
+      writerRef.current = port.writable.getWriter();
+      setConnected(true);
+    } catch {
+      setConnected(false);
+    }
+  }, []);
+
+  const send = useCallback(async (signal: 'R' | 'G') => {
+    if (!writerRef.current) return;
+    try {
+      await writerRef.current.write(new TextEncoder().encode(signal + '\n'));
+    } catch { /* 연결 끊김 무시 */ }
+  }, []);
+
+  return { connected, connect, send };
+}

--- a/src/features/meeting/useChunkedRecorder.ts
+++ b/src/features/meeting/useChunkedRecorder.ts
@@ -1,0 +1,86 @@
+import { useRef, useState, useCallback } from 'react';
+import apiClient from '@/api/client';
+
+type CalibrationState = 'idle' | 'leader' | 'member' | 'done';
+
+export function useChunkedRecorder(meetingId: number) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [calibrationState, setCalibrationState] = useState<CalibrationState>('idle');
+  const [elapsed, setElapsed] = useState(0);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const chunkIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const elapsedRef = useRef(0);
+  const chunkCountRef = useRef(0); // 1=리더 캘리브레이션 전송, 2=멤버 캘리브레이션 전송, 3+=프로덕션
+
+  const sendCalibration = useCallback(async (role: 'leader' | 'member', blob: Blob) => {
+    const form = new FormData();
+    form.append('audio', blob, 'calib.webm');
+    await apiClient.post(`/api/v1/meetings/${meetingId}/calibrate/${role}`, form);
+  }, [meetingId]);
+
+  const sendChunk = useCallback(async (blob: Blob) => {
+    const form = new FormData();
+    form.append('audio', blob, 'chunk.webm');
+    await apiClient.post(`/api/v1/meetings/${meetingId}/audio-chunk`, form).catch(() => {});
+  }, [meetingId]);
+
+  const start = useCallback(async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    streamRef.current = stream;
+    chunksRef.current = [];
+    elapsedRef.current = 0;
+    chunkCountRef.current = 0;
+
+    const mr = new MediaRecorder(stream, { mimeType: 'audio/webm', audioBitsPerSecond: 16000 });
+    mr.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data); };
+    recorderRef.current = mr;
+    mr.start(1000);
+    setIsRecording(true);
+    setCalibrationState('leader');
+
+    timerRef.current = setInterval(() => {
+      setElapsed((t) => { elapsedRef.current = t + 1; return t + 1; });
+    }, 1000);
+
+    // 5초마다: 1회=리더 캘리브레이션, 2회=멤버 캘리브레이션, 3회~=프로덕션 청크
+    chunkIntervalRef.current = setInterval(async () => {
+      const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+      chunksRef.current = [];
+      chunkCountRef.current++;
+
+      if (chunkCountRef.current === 1) {
+        await sendCalibration('leader', blob);
+        setCalibrationState('member');
+      } else if (chunkCountRef.current === 2) {
+        await sendCalibration('member', blob);
+        setCalibrationState('done');
+      } else {
+        sendChunk(blob);
+      }
+    }, 5000);
+  }, [sendCalibration, sendChunk]);
+
+  const stop = useCallback((): Promise<{ blob: Blob; durationSec: number }> => {
+    return new Promise((resolve) => {
+      const recorder = recorderRef.current;
+      if (!recorder) { resolve({ blob: new Blob(), durationSec: 0 }); return; }
+      const durationSec = elapsedRef.current;
+      recorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        streamRef.current?.getTracks().forEach((t) => t.stop());
+        if (timerRef.current) clearInterval(timerRef.current);
+        if (chunkIntervalRef.current) clearInterval(chunkIntervalRef.current);
+        setIsRecording(false);
+        setCalibrationState('idle');
+        resolve({ blob, durationSec });
+      };
+      recorder.stop();
+    });
+  }, []);
+
+  return { isRecording, calibrationState, elapsed, start, stop };
+}

--- a/src/features/meeting/useChunkedRecorder.ts
+++ b/src/features/meeting/useChunkedRecorder.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import apiClient from '@/api/client';
 
 type CalibrationState = 'idle' | 'leader' | 'member' | 'done';
@@ -11,6 +11,7 @@ export function useChunkedRecorder(meetingId: number) {
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<Blob[]>([]);
+  const allChunksRef = useRef<Blob[]>([]); // 전체 녹음 누적 (stop() 시 사용)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const chunkIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const elapsedRef = useRef(0);
@@ -32,11 +33,17 @@ export function useChunkedRecorder(meetingId: number) {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     streamRef.current = stream;
     chunksRef.current = [];
+    allChunksRef.current = [];
     elapsedRef.current = 0;
     chunkCountRef.current = 0;
 
     const mr = new MediaRecorder(stream, { mimeType: 'audio/webm', audioBitsPerSecond: 16000 });
-    mr.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data); };
+    mr.ondataavailable = (e) => {
+      if (e.data.size > 0) {
+        chunksRef.current.push(e.data);
+        allChunksRef.current.push(e.data);
+      }
+    };
     recorderRef.current = mr;
     mr.start(1000);
     setIsRecording(true);
@@ -52,14 +59,21 @@ export function useChunkedRecorder(meetingId: number) {
       chunksRef.current = [];
       chunkCountRef.current++;
 
-      if (chunkCountRef.current === 1) {
-        await sendCalibration('leader', blob);
-        setCalibrationState('member');
-      } else if (chunkCountRef.current === 2) {
-        await sendCalibration('member', blob);
-        setCalibrationState('done');
-      } else {
-        sendChunk(blob);
+      try {
+        if (chunkCountRef.current === 1) {
+          await sendCalibration('leader', blob);
+          setCalibrationState('member');
+        } else if (chunkCountRef.current === 2) {
+          await sendCalibration('member', blob);
+          setCalibrationState('done');
+        } else {
+          sendChunk(blob);
+        }
+      } catch (error) {
+        console.error('Calibration or chunk transmission failed:', error);
+        // 실패해도 캘리브레이션 상태는 진행시켜 녹음이 멈추지 않도록 함
+        if (chunkCountRef.current === 1) setCalibrationState('member');
+        else if (chunkCountRef.current === 2) setCalibrationState('done');
       }
     }, 5000);
   }, [sendCalibration, sendChunk]);
@@ -70,7 +84,7 @@ export function useChunkedRecorder(meetingId: number) {
       if (!recorder) { resolve({ blob: new Blob(), durationSec: 0 }); return; }
       const durationSec = elapsedRef.current;
       recorder.onstop = () => {
-        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const blob = new Blob(allChunksRef.current, { type: 'audio/webm' }); // 전체 누적 사용
         streamRef.current?.getTracks().forEach((t) => t.stop());
         if (timerRef.current) clearInterval(timerRef.current);
         if (chunkIntervalRef.current) clearInterval(chunkIntervalRef.current);
@@ -80,6 +94,15 @@ export function useChunkedRecorder(meetingId: number) {
       };
       recorder.stop();
     });
+  }, []);
+
+  // 언마운트 시 리소스 정리
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      if (chunkIntervalRef.current) clearInterval(chunkIntervalRef.current);
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+    };
   }, []);
 
   return { isRecording, calibrationState, elapsed, start, stop };

--- a/src/features/meeting/useTalkRatioStream.ts
+++ b/src/features/meeting/useTalkRatioStream.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+interface TalkRatioEvent {
+  leaderRatio: number;
+  memberRatio: number;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080';
+
+export function useTalkRatioStream(meetingId: number | null) {
+  const [ratio, setRatio] = useState<TalkRatioEvent | null>(null);
+
+  useEffect(() => {
+    if (!meetingId) return;
+    const token = localStorage.getItem('token');
+    const url = `${API_BASE}/api/v1/meetings/${meetingId}/talk-ratio/stream`;
+    const es = new EventSource(token ? `${url}?token=${token}` : url);
+
+    es.addEventListener('talkRatio', (e) => {
+      try {
+        setRatio(JSON.parse(e.data));
+      } catch { /* ignore */ }
+    });
+
+    es.onerror = () => es.close();
+
+    return () => es.close();
+  }, [meetingId]);
+
+  return ratio;
+}

--- a/src/features/meeting/useTalkRatioStream.ts
+++ b/src/features/meeting/useTalkRatioStream.ts
@@ -11,6 +11,7 @@ export function useTalkRatioStream(meetingId: number | null) {
   const [ratio, setRatio] = useState<TalkRatioEvent | null>(null);
 
   useEffect(() => {
+    setRatio(null); // meetingId 변경 시 이전 데이터 초기화
     if (!meetingId) return;
     const token = localStorage.getItem('token');
     const url = `${API_BASE}/api/v1/meetings/${meetingId}/talk-ratio/stream`;
@@ -22,8 +23,7 @@ export function useTalkRatioStream(meetingId: number | null) {
       } catch { /* ignore */ }
     });
 
-    es.onerror = () => es.close();
-
+    // onerror 강제 close 제거 — 브라우저 자체 auto-reconnect 활용
     return () => es.close();
   }, [meetingId]);
 

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import PageLayout from "@/components/layout/PageLayout";
 import { useChunkedRecorder } from "@/features/meeting/useChunkedRecorder";
+import { useTalkRatioStream } from "@/features/meeting/useTalkRatioStream";
 import TalkRatioBadge from "@/components/meeting/TalkRatioBadge";
 import { useUploadRecording } from "@/features/meeting/useUploadRecording";
 import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
@@ -28,6 +29,7 @@ export default function MeetingDetailPage() {
   const [showStart, setShowStart] = useState(false);
   const [showEnd, setShowEnd] = useState(false);
   const [localStatus, setLocalStatus] = useState<LocalStatus>("pending");
+  const ratio = useTalkRatioStream(localStatus === "recording" ? (meetingId ? Number(meetingId) : null) : null);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const pendingUploadRef = useRef<{ blob: Blob; durationSec: number } | null>(null);
   const { completed: surveyCompleted } = useSurveyCompletion(
@@ -250,7 +252,7 @@ export default function MeetingDetailPage() {
           )}
           {localStatus === "recording" && (
             <div className="border-t border-gray-200 px-8 py-6 flex flex-col items-center gap-3">
-              <TalkRatioBadge leaderRatio={null} calibrationState={recorder.calibrationState} />
+              <TalkRatioBadge leaderRatio={ratio?.leaderRatio ?? null} calibrationState={recorder.calibrationState} />
               <span className="text-sm font-medium text-[#5F74FA]">🎙 녹음 중입니다</span>
               <span className="text-xs text-gray-400">아래 플로팅 바에서 미팅을 종료할 수 있습니다.</span>
             </div>
@@ -265,7 +267,7 @@ export default function MeetingDetailPage() {
               placeholder="나만 볼 수 있는 메모입니다."
             />
           </div>
-          <IotPanel meetingId={meetingId} isRecording={localStatus === 'recording'} />
+          <IotPanel ratio={ratio} isRecording={localStatus === 'recording'} />
         </div>
 
         <StartMeetingModal isOpen={showStart} onClose={() => setShowStart(false)} onStart={handleStartRecording} />

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import PageLayout from "@/components/layout/PageLayout";
-import { useRecorder } from "@/features/meeting/useRecorder";
+import { useChunkedRecorder } from "@/features/meeting/useChunkedRecorder";
+import TalkRatioBadge from "@/components/meeting/TalkRatioBadge";
 import { useUploadRecording } from "@/features/meeting/useUploadRecording";
 import { useMeetingDetail } from "@/features/meeting/useMeetingDetail";
 import StartMeetingModal from "@/components/ui/StartMeetingModal";
@@ -22,7 +23,7 @@ export default function MeetingDetailPage() {
   const navigate = useNavigate();
   const { meeting, loading, error } = useMeetingDetail(meetingId);
   const { data: briefing, loading: briefingLoading, error: briefingError, retry: retryBriefing } = usePreBriefing(meetingId);
-  const recorder = useRecorder();
+  const recorder = useChunkedRecorder(meetingId ? Number(meetingId) : 0);
   const { upload } = useUploadRecording();
   const [showStart, setShowStart] = useState(false);
   const [showEnd, setShowEnd] = useState(false);
@@ -248,7 +249,8 @@ export default function MeetingDetailPage() {
             </div>
           )}
           {localStatus === "recording" && (
-            <div className="border-t border-gray-200 px-8 py-6 flex flex-col items-center gap-2">
+            <div className="border-t border-gray-200 px-8 py-6 flex flex-col items-center gap-3">
+              <TalkRatioBadge leaderRatio={null} calibrationState={recorder.calibrationState} />
               <span className="text-sm font-medium text-[#5F74FA]">🎙 녹음 중입니다</span>
               <span className="text-xs text-gray-400">아래 플로팅 바에서 미팅을 종료할 수 있습니다.</span>
             </div>
@@ -271,7 +273,7 @@ export default function MeetingDetailPage() {
         <RecordingFloatingBar
           isRecording={recorder.isRecording}
           elapsed={recorder.elapsed}
-          audioLevel={recorder.audioLevel}
+          audioLevel={0}
           isLeader={true}
           onEndClick={() => setShowEnd(true)}
         />


### PR DESCRIPTION
## Summary
BE의 오디오 청크 분석 결과를 SSE로 수신해 아두이노 LED를 제어하는 FE 구현

## 새 파일
- `features/meeting/useChunkedRecorder.ts` — 5초마다 청크 전송, 첫 2회=캘리브레이션
- `features/meeting/useTalkRatioStream.ts` — SSE 구독 훅
- `features/meeting/useArduinoSerial.ts` — Web Serial API 훅
- `components/meeting/TalkRatioBadge.tsx` — 캘리브레이션 안내 + 비율 뱃지

## 변경 파일
- `components/iot/IotPanel.tsx` — useIoTTalkRatio(VAD) → useTalkRatioStream + useArduinoSerial 교체
- `pages/leader/MeetingDetailPage.tsx` — useRecorder → useChunkedRecorder 교체, TalkRatioBadge 추가

## 동작 흐름
1. 미팅 시작 → 녹음 시작
2. 첫 5초: 리더 캘리브레이션 전송, 다음 5초: 멤버 캘리브레이션 전송
3. 이후 매 5초 청크 → BE 발화 비율 계산 → SSE 수신
4. leaderRatio ≥ 70% → 아두이노 빨간 LED / 미만 → 초록 LED

## Test plan
- [ ] `npm run type-check` 통과
- [ ] 미팅 녹음 시작 시 캘리브레이션 안내 문구 표시 확인
- [ ] IotPanel에서 비율 실시간 업데이트 확인
- [ ] 아두이노 연결 후 LED 제어 확인 (Chrome 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)