### PR TITLE
feat: 리더 대시보드 팀 코칭 카드 및 멤버별 미이행 약속 아코디언 기능 추가

### DIFF
--- a/src/api/promises.ts
+++ b/src/api/promises.ts
@@ -1,6 +1,6 @@
 import apiClient from './client';
 import type { ApiResponse } from './types';
-import type { OverduePromise } from '@/types/promise';
+import type { MemberPromiseSummary, OverduePromise } from '@/types/promise';
 
 export async function fetchOverduePromises(memberId?: number | string): Promise<OverduePromise[]> {
   const res = await apiClient.get<ApiResponse<OverduePromise[]>>('/api/v1/promises/overdue', {
@@ -8,4 +8,15 @@ export async function fetchOverduePromises(memberId?: number | string): Promise<
   });
 
   return res.data.data;
+}
+
+export async function fetchPromiseSummary(teamId: string): Promise<MemberPromiseSummary[]> {
+  const res = await apiClient.get<ApiResponse<{ memberPromises: MemberPromiseSummary[] }>>(
+    `/api/v1/teams/${teamId}/promises/summary`,
+  );
+  return res.data.data.memberPromises;
+}
+
+export async function completePromise(promiseId: string): Promise<void> {
+  await apiClient.patch(`/api/v1/promises/${promiseId}`, { status: 'COMPLETED' });
 }

--- a/src/api/teamDashboard.ts
+++ b/src/api/teamDashboard.ts
@@ -3,6 +3,7 @@ import type { ApiResponse } from './types';
 import type { BlockerPyramidData } from '@/types/blocker';
 import type { CommunicationBalance, RadarDataPoint } from '@/types/analysis';
 import type { TeamHealthScoreData } from '@/types/teamHealth';
+import type { TeamCoachingData } from '@/types/coaching';
 
 export async function fetchTeamDashboard(teamId: string): Promise<TeamHealthScoreData> {
   const res = await apiClient.get<ApiResponse<TeamHealthScoreData>>(
@@ -30,4 +31,11 @@ export async function fetchTalkRatioRanking(teamId: string): Promise<Communicati
     `/api/v1/teams/${teamId}/talk-ratio-ranking`,
   );
   return res.data.data;
+}
+
+export async function fetchTeamCoaching(teamId: string): Promise<TeamCoachingData> {
+  const res = await apiClient.get<ApiResponse<{ teamCoaching: TeamCoachingData }>>(
+    `/api/v1/teams/${teamId}/coaching`,
+  );
+  return res.data.data.teamCoaching;
 }

--- a/src/components/blocker/BlockerDetailCard.tsx
+++ b/src/components/blocker/BlockerDetailCard.tsx
@@ -21,11 +21,11 @@ export default function BlockerDetailCard({ item }: BlockerDetailCardProps) {
         </div>
       </div>
 
-      {item.mentionedMembers && item.mentionedMembers.length > 0 && (
+      {item.memberNames && item.memberNames.length > 0 && (
         <div className="mt-3">
           <p className="mb-1.5 text-xs font-medium text-gray-500">언급 팀원</p>
           <div className="flex flex-wrap gap-1.5">
-            {item.mentionedMembers.map((member) => (
+            {item.memberNames.map((member) => (
               <span key={member} className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-600">
                 {member}
               </span>

--- a/src/components/charts/BlockerPyramid.tsx
+++ b/src/components/charts/BlockerPyramid.tsx
@@ -152,11 +152,11 @@ export default function BlockerPyramid({
           <p className="font-semibold text-gray-900">{tooltip.item.keyword}</p>
           <p className="mt-1 text-gray-500">언급 횟수: {tooltip.item.count}</p>
           <p className="text-gray-500">언급 인원 수: {tooltip.item.mentionedBy}</p>
-          {tooltip.item.mentionedMembers && tooltip.item.mentionedMembers.length > 0 && (
+          {tooltip.item.memberNames && tooltip.item.memberNames.length > 0 && (
             <div className="mt-2 max-w-[220px]">
               <p className="mb-1 font-medium text-gray-700">언급 팀원</p>
               <div className="flex flex-wrap gap-1">
-                {tooltip.item.mentionedMembers.map((member) => (
+                {tooltip.item.memberNames.map((member) => (
                   <span key={member} className="rounded-full bg-gray-50 px-2 py-0.5 text-gray-500">
                     {member}
                   </span>

--- a/src/components/feedback/TeamCoachingCard.tsx
+++ b/src/components/feedback/TeamCoachingCard.tsx
@@ -1,0 +1,45 @@
+import Card from '@/components/ui/Card';
+import Badge from '@/components/ui/Badge';
+import type { TeamCoachingData } from '@/types/coaching';
+
+interface Props {
+  data: TeamCoachingData;
+}
+
+export default function TeamCoachingCard({ data }: Props) {
+  return (
+    <Card className="mb-5 p-5">
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        팀 코칭
+      </p>
+
+      <div className="bg-gray-50 rounded-lg px-4 py-3 mb-4">
+        <p className="text-sm text-gray-700">{data.overallAssessment}</p>
+      </div>
+
+      <div className="flex flex-col gap-2 mb-4">
+        {data.insights.map((insight, i) => (
+          <div key={i} className="flex items-start gap-2">
+            <Badge
+              label={insight.type === 'ATTENTION' ? '주의' : '긍정'}
+              color={insight.type === 'ATTENTION' ? 'orange' : 'green'}
+            />
+            <p className="text-sm text-gray-800 flex-1">{insight.content}</p>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+        제안 액션
+      </p>
+      <div className="flex flex-col gap-2">
+        {data.suggestedActions.map((action, i) => (
+          <div key={i} className="flex items-start gap-2 bg-gray-50 rounded-lg px-3 py-2">
+            <span className="text-sm font-medium text-teal-600 flex-shrink-0">{i + 1}.</span>
+            <p className="text-sm text-gray-700">{action}</p>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/feedback/TeamCoachingCard.tsx
+++ b/src/components/feedback/TeamCoachingCard.tsx
@@ -4,12 +4,13 @@ import type { TeamCoachingData } from '@/types/coaching';
 
 interface Props {
   data: TeamCoachingData;
+  variant?: 'standalone' | 'inline';
 }
 
-export default function TeamCoachingCard({ data }: Props) {
+function TeamCoachingCardContent({ data }: { data: TeamCoachingData }) {
   return (
-    <Card className="mb-5 p-5">
-      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+    <>
+      <p className="text-base font-semibold text-gray-700 mb-3">
         팀 코칭
       </p>
 
@@ -29,7 +30,7 @@ export default function TeamCoachingCard({ data }: Props) {
         ))}
       </div>
 
-      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+      <p className="text-base font-semibold text-gray-700 mb-2">
         제안 액션
       </p>
       <div className="flex flex-col gap-2">
@@ -40,6 +41,18 @@ export default function TeamCoachingCard({ data }: Props) {
           </div>
         ))}
       </div>
+    </>
+  );
+}
+
+export default function TeamCoachingCard({ data, variant = 'standalone' }: Props) {
+  if (variant === 'inline') {
+    return <TeamCoachingCardContent data={data} />;
+  }
+
+  return (
+    <Card className="mb-5 p-5">
+      <TeamCoachingCardContent data={data} />
     </Card>
   );
 }

--- a/src/components/feedback/TeamHealthScoreCard.tsx
+++ b/src/components/feedback/TeamHealthScoreCard.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import type React from 'react';
 import Card from '@/components/ui/Card';
 import type { TeamHealthScoreData, TeamHealthTrend } from '@/types/teamHealth';
 
 export interface TeamHealthScoreCardProps {
   data: TeamHealthScoreData;
+  coachingSlot?: React.ReactNode;
 }
 
 const trendMessageStyles: Record<TeamHealthTrend, string> = {
@@ -20,7 +22,7 @@ const trendLabels: Record<TeamHealthTrend, string> = {
 
 const TEAM_HEALTH_BAR_COLOR = '#2dd4bf';
 
-export default function TeamHealthScoreCard({ data }: TeamHealthScoreCardProps) {
+export default function TeamHealthScoreCard({ data, coachingSlot }: TeamHealthScoreCardProps) {
   const [alertsOpen, setAlertsOpen] = useState(false);
   const score = Math.round(data.teamHealthScore);
   const alerts = data.alerts ?? [];
@@ -28,7 +30,7 @@ export default function TeamHealthScoreCard({ data }: TeamHealthScoreCardProps) 
 
   return (
     <Card className="mb-5 p-5">
-      <div className="grid gap-5">
+      <div className="flex flex-col gap-5">
         <div className="min-w-0">
           <p className="text-base font-semibold text-gray-700">Team Health Score</p>
           <div className="mt-3 flex items-end gap-2">
@@ -47,9 +49,15 @@ export default function TeamHealthScoreCard({ data }: TeamHealthScoreCardProps) 
             />
           </div>
           <p className={`mt-3 text-sm font-semibold ${trendMessageStyles[data.trend]}`}>
-            현재 추세는 {trendLabels[data.trend]} 상태입니다. 
+            현재 추세는 {trendLabels[data.trend]} 상태입니다.
           </p>
         </div>
+
+        {coachingSlot && (
+          <div className="border-t border-gray-100 pt-4">
+            {coachingSlot}
+          </div>
+        )}
 
         <div className="border-t border-gray-100 pt-4">
           <button

--- a/src/components/report/PromiseSummaryCard.tsx
+++ b/src/components/report/PromiseSummaryCard.tsx
@@ -1,0 +1,87 @@
+import Accordion from '@/components/ui/Accordion';
+import Badge from '@/components/ui/Badge';
+import type { MemberPromiseSummary, PromiseSummaryItem } from '@/types/promise';
+
+export interface PromiseSummaryCardProps {
+  data: MemberPromiseSummary[];
+  onComplete: (promiseId: string) => void;
+  loading?: boolean;
+  error?: string | null;
+}
+
+function PromiseItemRow({
+  promise,
+  onComplete,
+}: {
+  promise: PromiseSummaryItem;
+  onComplete: (id: string) => void;
+}) {
+  const isOverdue = promise.status === 'OVERDUE';
+
+  return (
+    <div
+      className={`flex gap-3 py-2.5 border-b border-gray-100 last:border-b-0 ${
+        isOverdue ? 'bg-red-50 -mx-3 px-3 rounded' : ''
+      }`}
+    >
+      <input
+        type="checkbox"
+        className="mt-0.5 flex-shrink-0 w-4 h-4 accent-teal-500 cursor-pointer"
+        onChange={() => onComplete(promise.promiseId)}
+      />
+      <div className="min-w-0">
+        <p className={`text-sm font-medium leading-snug ${isOverdue ? 'text-red-700' : 'text-gray-800'}`}>
+          {promise.content}
+        </p>
+        {promise.context && (
+          <p className="mt-0.5 text-xs text-gray-400 leading-snug">{promise.context}</p>
+        )}
+        <p className="mt-0.5 text-xs text-gray-400">{promise.meetingTitle}</p>
+        {isOverdue && (
+          <span className="mt-1 inline-block text-xs font-semibold text-red-500">기한 초과</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function PromiseSummaryCard({
+  data,
+  onComplete,
+  loading,
+  error,
+}: PromiseSummaryCardProps) {
+  if (loading) {
+    return <p className="py-4 text-sm font-medium text-gray-400">미이행 약속을 불러오는 중입니다.</p>;
+  }
+  if (error) {
+    return <p className="text-sm font-medium text-gray-400">{error}</p>;
+  }
+  if (data.length === 0) {
+    return <p className="py-4 text-sm font-medium text-gray-400">미이행 약속이 없습니다.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {data.map(member => {
+        const { stats } = member;
+        const badgeColor = stats.overdue > 0 ? 'red' : stats.pending > 0 ? 'yellow' : 'green';
+
+        return (
+          <Accordion
+            key={member.memberId}
+            title={member.memberName}
+            rightElement={
+              <Badge label={`${stats.completed}/${stats.total} 완료`} color={badgeColor} />
+            }
+            defaultOpen
+          >
+            {member.promises.map(promise => (
+              <PromiseItemRow key={promise.promiseId} promise={promise} onComplete={onComplete} />
+            ))}
+          </Accordion>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -3,31 +3,36 @@ import { useState, type ReactNode } from 'react';
 interface AccordionProps {
   title: string;
   children: ReactNode;
+  rightElement?: ReactNode;
+  defaultOpen?: boolean;
 }
 
-export default function Accordion({ title, children }: AccordionProps) {
-  const [open, setOpen] = useState(false);
+export default function Accordion({ title, children, rightElement, defaultOpen = false }: AccordionProps) {
+  const [open, setOpen] = useState(defaultOpen);
   return (
     <div className="border border-gray-100 rounded-lg">
       <button
         className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-gray-800"
         onClick={() => setOpen(!open)}
       >
-        {title}
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          style={{
-            transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
-            transition: 'transform 0.2s',
-          }}
-        >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
+        <span>{title}</span>
+        <div className="flex items-center gap-2">
+          {rightElement}
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            style={{
+              transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s',
+            }}
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </div>
       </button>
       {open && <div className="px-4 pb-3">{children}</div>}
     </div>

--- a/src/data/mockPromiseSummary.ts
+++ b/src/data/mockPromiseSummary.ts
@@ -1,0 +1,57 @@
+import type { MemberPromiseSummary } from '@/types/promise';
+
+export const MOCK_PROMISE_SUMMARY: MemberPromiseSummary[] = [
+  {
+    memberId: 'member-1',
+    memberName: '김민준',
+    promises: [
+      {
+        promiseId: 'p-1',
+        content: 'QA 리소스 이슈 에스컬레이션',
+        context: '스프린트 회고 중 QA 병목 논의',
+        status: 'OVERDUE',
+        createdAt: '2026-05-12',
+        meetingTitle: '5/12 1on1 미팅',
+      },
+      {
+        promiseId: 'p-2',
+        content: '신규 온보딩 문서 업데이트',
+        context: '신규 입사자 적응 이슈 논의 중 제안',
+        status: 'PENDING',
+        createdAt: '2026-05-28',
+        meetingTitle: '5/28 1on1 미팅',
+      },
+    ],
+    stats: { total: 5, completed: 3, pending: 1, overdue: 1 },
+  },
+  {
+    memberId: 'member-2',
+    memberName: '강다은',
+    promises: [
+      {
+        promiseId: 'p-3',
+        content: 'AWS 프로덕션 접근 권한 부여',
+        context: '배포 권한 이슈 논의',
+        status: 'PENDING',
+        createdAt: '2026-05-20',
+        meetingTitle: '5/20 1on1 미팅',
+      },
+    ],
+    stats: { total: 3, completed: 2, pending: 1, overdue: 0 },
+  },
+  {
+    memberId: 'member-3',
+    memberName: '이서연',
+    promises: [
+      {
+        promiseId: 'p-4',
+        content: 'MSA 전환 성과 5분 발표 준비',
+        context: '팀 공유 세션 기획 논의 중 자발적 제안',
+        status: 'OVERDUE',
+        createdAt: '2026-05-10',
+        meetingTitle: '5/10 1on1 미팅',
+      },
+    ],
+    stats: { total: 4, completed: 3, pending: 0, overdue: 1 },
+  },
+];

--- a/src/data/mockTeamCoaching.ts
+++ b/src/data/mockTeamCoaching.ts
@@ -1,0 +1,21 @@
+import type { TeamCoachingData } from '@/types/coaching';
+
+export const MOCK_TEAM_COACHING: TeamCoachingData = {
+  overallAssessment: '4명 중 2명이 SILENT_RISK 사분면에 위치합니다.',
+  insights: [
+    {
+      type: 'ATTENTION',
+      content: '지수님의 Safety Score가 최근 3회 평균 대비 35% 하락했습니다 (72→47).',
+      relatedMemberId: 'mock-member-1',
+    },
+    {
+      type: 'POSITIVE',
+      content: '민수님의 Initiative 발화가 3회 연속 증가 추세입니다 (1→2→4회).',
+      relatedMemberId: 'mock-member-2',
+    },
+  ],
+  suggestedActions: [
+    '다음 1on1에서 지수님에게 열린 질문으로 시작해보세요.',
+    '민수님의 자발적 제안에 대해 구체적 피드백을 주세요.',
+  ],
+};

--- a/src/features/leader/usePromiseSummary.ts
+++ b/src/features/leader/usePromiseSummary.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+import { completePromise, fetchPromiseSummary } from '@/api/promises';
+import { MOCK_PROMISE_SUMMARY } from '@/data/mockPromiseSummary';
+import type { MemberPromiseSummary } from '@/types/promise';
+
+export function usePromiseSummary(teamId?: string) {
+  const [data, setData] = useState<MemberPromiseSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!teamId) {
+      setData([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (import.meta.env.VITE_USE_MOCK === 'true') {
+      setData(MOCK_PROMISE_SUMMARY);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let ignore = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchPromiseSummary(teamId!);
+        if (!ignore) setData(result);
+      } catch {
+        if (!ignore) {
+          setData([]);
+          setError('미이행 약속 목록을 불러오지 못했습니다.');
+        }
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      ignore = true;
+    };
+  }, [teamId]);
+
+  // 체크박스 완료 시 낙관적으로 해당 약속 제거 후 PATCH 호출
+  const complete = useCallback(async (promiseId: string) => {
+    setData(prev =>
+      prev
+        .map(member => ({
+          ...member,
+          promises: member.promises.filter(p => p.promiseId !== promiseId),
+        }))
+        .filter(member => member.promises.length > 0),
+    );
+    try {
+      await completePromise(promiseId);
+    } catch {
+      // silent — 낙관적 업데이트 유지
+    }
+  }, []);
+
+  return { data, loading, error, complete };
+}

--- a/src/features/leader/useTeamCoaching.ts
+++ b/src/features/leader/useTeamCoaching.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { fetchTeamCoaching } from '@/api/teamDashboard';
+import { MOCK_TEAM_COACHING } from '@/data/mockTeamCoaching';
+import type { TeamCoachingData } from '@/types/coaching';
+
+export function useTeamCoaching(teamId?: string) {
+  const [data, setData] = useState<TeamCoachingData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!teamId) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (import.meta.env.VITE_USE_MOCK === 'true') {
+      setData(MOCK_TEAM_COACHING);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let ignore = false;
+    const resolvedTeamId = teamId;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchTeamCoaching(resolvedTeamId);
+        if (!ignore) setData(result);
+      } catch {
+        if (!ignore) {
+          setData(null);
+          setError('팀 코칭 데이터를 불러오지 못했습니다.');
+        }
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+
+    load();
+
+    return () => {
+      ignore = true;
+    };
+  }, [teamId]);
+
+  return { data, loading, error };
+}

--- a/src/pages/leader/LeaderDashboard.tsx
+++ b/src/pages/leader/LeaderDashboard.tsx
@@ -149,27 +149,25 @@ export default function LeaderDashboard() {
             <ErrorState label="Team Health Score" />
           </Card>
         )}
-        {!teamHealthLoading && teamHealthScore && <TeamHealthScoreCard data={teamHealthScore} />}
+        {!teamHealthLoading && teamHealthScore && (
+          <TeamHealthScoreCard
+            data={teamHealthScore}
+            coachingSlot={
+              coachingLoading ? (
+                <p className="text-sm font-medium text-gray-500">팀 코칭 데이터를 불러오는 중입니다.</p>
+              ) : coachingError ? (
+                <ErrorState label="팀 코칭" />
+              ) : coachingData ? (
+                <TeamCoachingCard data={coachingData} variant="inline" />
+              ) : (
+                <p className="text-sm font-medium text-gray-400">아직 팀 코칭 데이터가 없습니다.</p>
+              )
+            }
+          />
+        )}
         {!teamHealthLoading && !teamHealthError && !teamHealthScore && (
           <Card className="mb-5 p-5">
             <p className="text-sm font-medium text-gray-400">아직 Team Health Score를 계산할 데이터가 없습니다.</p>
-          </Card>
-        )}
-
-        {coachingLoading && (
-          <Card className="mb-5 p-5">
-            <p className="text-sm font-medium text-gray-500">팀 코칭 데이터를 불러오는 중입니다.</p>
-          </Card>
-        )}
-        {!coachingLoading && coachingError && (
-          <Card className="mb-5 p-5">
-            <ErrorState label="팀 코칭" />
-          </Card>
-        )}
-        {!coachingLoading && coachingData && <TeamCoachingCard data={coachingData} />}
-        {!coachingLoading && !coachingError && !coachingData && (
-          <Card className="mb-5 p-5">
-            <p className="text-sm font-medium text-gray-400">아직 팀 코칭 데이터가 없습니다.</p>
           </Card>
         )}
 

--- a/src/pages/leader/LeaderDashboard.tsx
+++ b/src/pages/leader/LeaderDashboard.tsx
@@ -10,12 +10,12 @@ import { useRadarData } from '@/features/leader/useRadarData';
 import { useBlockerPyramid } from '@/features/leader/useBlockerPyramid';
 import { useTeamHealthScore } from '@/features/leader/useTeamHealthScore';
 import { useTalkRatioRanking } from '@/features/leader/useTalkRatioRanking';
-import { usePromises } from '@/features/leader/usePromises';
+import PromiseSummaryCard from '@/components/report/PromiseSummaryCard';
+import { usePromiseSummary } from '@/features/leader/usePromiseSummary';
 import { useAuthStore } from '@/stores/authStore';
 import TeamCoachingCard from '@/components/feedback/TeamCoachingCard';
 import { useTeamCoaching } from '@/features/leader/useTeamCoaching';
 import type { CommunicationBalance } from '@/types/analysis';
-import type { OverduePromise } from '@/types/promise';
 
 // ── Talk Ratio Bar ─────────────────────────────────────────────────────────────
 
@@ -69,28 +69,6 @@ function ErrorState({ label }: { label: string }) {
   );
 }
 
-function formatDueDate(date: string) {
-  const parsed = new Date(date);
-  if (Number.isNaN(parsed.getTime())) return date;
-
-  return parsed.toLocaleDateString('ko-KR', {
-    month: 'long',
-    day: 'numeric',
-  });
-}
-
-function PromiseRow({ promise }: { promise: OverduePromise }) {
-  return (
-    <div className="border-t border-gray-100 py-3 first:border-t-0 first:pt-0 last:pb-0">
-      <p className="text-sm text-gray-950">
-        <span>{promise.memberName}</span>님과의 약속
-      </p>
-      <p className="mt-1 text-sm font-bold leading-5 text-gray-950">{promise.content}</p>
-      <p className="mt-1 text-xs font-medium text-gray-400">마감일 {formatDueDate(promise.dueDate)}</p>
-    </div>
-  );
-}
-
 type ChartTab = 'radar' | 'blocker';
 
 export default function LeaderDashboard() {
@@ -116,10 +94,11 @@ export default function LeaderDashboard() {
     error: talkRatioError,
   } = useTalkRatioRanking(teamId);
   const {
-    promises,
+    data: promiseSummary,
     loading: promisesLoading,
     error: promisesError,
-  } = usePromises(teamId);
+    complete: completePromise,
+  } = usePromiseSummary(teamId);
   const {
     data: coachingData,
     loading: coachingLoading,
@@ -282,7 +261,7 @@ export default function LeaderDashboard() {
           </div>
 
           {/* Right: Communication Balance */}
-          <div className="w-[260px] flex-shrink-0 flex flex-col gap-4">
+          <div className="w-[360px] flex-shrink-0 flex flex-col gap-4">
             {/* Communication Balance */}
             <Card className="p-4">
               <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
@@ -310,22 +289,12 @@ export default function LeaderDashboard() {
               <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
                 미이행 약속
               </p>
-              <div className="flex flex-col">
-                {promisesLoading && (
-                  <p className="py-4 text-sm font-medium text-gray-400">미이행 약속을 불러오는 중입니다.</p>
-                )}
-                {!promisesLoading && promisesError && (
-                  <p className="text-sm font-medium text-gray-400">{promisesError}</p>
-                )}
-                {!promisesLoading && !promisesError && promises.length > 0 && (
-                  promises.map((promise) => (
-                    <PromiseRow key={promise.promiseId} promise={promise} />
-                  ))
-                )}
-                {!promisesLoading && !promisesError && promises.length === 0 && (
-                  <p className="py-4 text-sm font-medium text-gray-400">아직 미이행 약속이 없습니다.</p>
-                )}
-              </div>
+              <PromiseSummaryCard
+                data={promiseSummary}
+                onComplete={completePromise}
+                loading={promisesLoading}
+                error={promisesError}
+              />
             </Card>
           </div>
         </div>

--- a/src/pages/leader/LeaderDashboard.tsx
+++ b/src/pages/leader/LeaderDashboard.tsx
@@ -12,6 +12,8 @@ import { useTeamHealthScore } from '@/features/leader/useTeamHealthScore';
 import { useTalkRatioRanking } from '@/features/leader/useTalkRatioRanking';
 import { usePromises } from '@/features/leader/usePromises';
 import { useAuthStore } from '@/stores/authStore';
+import TeamCoachingCard from '@/components/feedback/TeamCoachingCard';
+import { useTeamCoaching } from '@/features/leader/useTeamCoaching';
 import type { CommunicationBalance } from '@/types/analysis';
 import type { OverduePromise } from '@/types/promise';
 
@@ -118,6 +120,11 @@ export default function LeaderDashboard() {
     loading: promisesLoading,
     error: promisesError,
   } = usePromises(teamId);
+  const {
+    data: coachingData,
+    loading: coachingLoading,
+    error: coachingError,
+  } = useTeamCoaching(teamId);
   const [activeTab, setActiveTab] = useState<ChartTab>('radar');
   const radarItems = radarData ?? [];
   const communicationItems = talkRatioRankings ?? [];
@@ -146,6 +153,23 @@ export default function LeaderDashboard() {
         {!teamHealthLoading && !teamHealthError && !teamHealthScore && (
           <Card className="mb-5 p-5">
             <p className="text-sm font-medium text-gray-400">아직 Team Health Score를 계산할 데이터가 없습니다.</p>
+          </Card>
+        )}
+
+        {coachingLoading && (
+          <Card className="mb-5 p-5">
+            <p className="text-sm font-medium text-gray-500">팀 코칭 데이터를 불러오는 중입니다.</p>
+          </Card>
+        )}
+        {!coachingLoading && coachingError && (
+          <Card className="mb-5 p-5">
+            <ErrorState label="팀 코칭" />
+          </Card>
+        )}
+        {!coachingLoading && coachingData && <TeamCoachingCard data={coachingData} />}
+        {!coachingLoading && !coachingError && !coachingData && (
+          <Card className="mb-5 p-5">
+            <p className="text-sm font-medium text-gray-400">아직 팀 코칭 데이터가 없습니다.</p>
           </Card>
         )}
 

--- a/src/types/blocker.ts
+++ b/src/types/blocker.ts
@@ -2,7 +2,7 @@ export interface BlockerPyramidItem {
   keyword: string;
   count: number;
   mentionedBy: number;
-  mentionedMembers?: string[];
+  memberNames?: string[];
 }
 
 export interface BlockerActionPrescription {

--- a/src/types/coaching.ts
+++ b/src/types/coaching.ts
@@ -1,0 +1,13 @@
+export type CoachingInsightType = 'ATTENTION' | 'POSITIVE';
+
+export interface CoachingInsight {
+  type: CoachingInsightType;
+  content: string;
+  relatedMemberId: string;
+}
+
+export interface TeamCoachingData {
+  overallAssessment: string;
+  insights: CoachingInsight[];
+  suggestedActions: string[];
+}

--- a/src/types/promise.ts
+++ b/src/types/promise.ts
@@ -21,3 +21,26 @@ export interface OverduePromise {
   fromMeetingRound: number
   memberName: string
 }
+
+export type SummaryPromiseStatus = 'PENDING' | 'OVERDUE'
+
+export interface PromiseSummaryItem {
+  promiseId: string
+  content: string
+  context: string
+  status: SummaryPromiseStatus
+  createdAt: string
+  meetingTitle: string
+}
+
+export interface MemberPromiseSummary {
+  memberId: string
+  memberName: string
+  promises: PromiseSummaryItem[]
+  stats: {
+    total: number
+    completed: number
+    pending: number
+    overdue: number
+  }
+}


### PR DESCRIPTION
## 변경 사항

### src/types/coaching.ts (신규)
- TeamCoachingData 타입 추가

### src/data/mockTeamCoaching.ts (신규)
- 팀 코칭 목 데이터 추가

### src/api/ (신규 함수)
- fetchTeamCoaching: GET /teams/{teamId}/coaching 호출
- fetchPromiseSummary: GET /teams/{teamId}/promises/summary 호출
- completePromise: PATCH /promises/{promiseId} 호출

### src/features/leader/ (신규 훅)
- useTeamCoaching: 팀 코칭 데이터 페치
- usePromiseSummary: 미이행 약속 summary 페치 + 완료 처리

### src/types/promise.ts
- SummaryPromiseStatus, PromiseSummaryItem, MemberPromiseSummary 타입 추가

### src/data/mockPromiseSummary.ts (신규)
- 멤버별 미이행 약속 목 데이터 추가

### src/components/ui/Accordion.tsx
- rightElement prop 추가 (배지 등 오른쪽 요소 표시)
- defaultOpen prop 추가 (기본 펼침 여부)

### src/components/feedback/TeamCoachingCard.tsx (신규)
- 팀 코칭 카드 컴포넌트

### src/components/report/PromiseSummaryCard.tsx (신규)
- 멤버별 아코디언 컴포넌트
- OVERDUE 약속 빨간 하이라이트 + "기한 초과" 표시
- 멤버 헤더에 "N/M 완료" 이행률 배지

### src/components/feedback/TeamHealthScoreCard.tsx
- coachingSlot prop 추가 — 팀 코칭 카드 슬롯 인라인 삽입

### src/pages/leader/LeaderDashboard.tsx
- TeamCoachingCard를 TeamHealthScoreCard 내부에 통합
- 미이행 약속 카드 내부를 PromiseSummaryCard로 교체
- 우측 사이드바 너비 260px → 360px 확장

## 동작 방식

대시보드 진입 시 팀 코칭 데이터와 미이행 약속 summary를 병렬로 페치한다.
팀 코칭 카드는 Team Health Score 카드 내부 슬롯에 표시된다.
미이행 약속 카드는 멤버별 아코디언으로 표시되며, PENDING/OVERDUE 약속만 포함된다.
체크박스 완료 시 낙관적으로 해당 항목을 즉시 제거하고 PATCH API를 호출한다.

## 테스트 포인트
- [ ] 팀 코칭 카드가 Team Health Score 카드 내부에 표시되는지 확인
- [ ] 미이행 약속이 멤버별 아코디언으로 표시되는지 확인
- [ ] OVERDUE 약속에 빨간 배경과 "기한 초과" 텍스트가 표시되는지 확인
- [ ] 멤버 헤더에 "N/M 완료" 배지가 정확히 표시되는지 확인
- [ ] 체크박스 클릭 시 해당 약속이 즉시 목록에서 사라지는지 확인
- [ ] VITE_USE_MOCK=true 환경에서 목 데이터가 정상 표시되는지 확인
