### PR TITLE
fix: 블로커 피라미드 발언 멤버 관련 api 변수명 수정

### DIFF
--- a/src/components/blocker/BlockerDetailCard.tsx
+++ b/src/components/blocker/BlockerDetailCard.tsx
@@ -21,17 +21,17 @@ export default function BlockerDetailCard({ item }: BlockerDetailCardProps) {
         </div>
       </div>
 
-      {item.memberNames && item.memberNames.length > 0 && (
-        <div className="mt-3">
-          <p className="mb-1.5 text-xs font-medium text-gray-500">언급 팀원</p>
-          <div className="flex flex-wrap gap-1.5">
-            {item.memberNames.map((member) => (
-              <span key={member} className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-600">
-                {member}
-              </span>
-            ))}
-          </div>
+      {item.relatedMembers && item.relatedMembers.length > 0 && (
+      <div className="mt-3">
+        <p className="mb-1.5 text-xs font-medium text-gray-500">언급 팀원</p>
+        <div className="flex flex-wrap gap-1.5">
+          {item.relatedMembers.map((member) => (
+            <span key={member.memberId} className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-600">
+              {member.memberName}
+            </span>
+          ))}
         </div>
+      </div>
       )}
     </div>
   );

--- a/src/components/charts/BlockerPyramid.tsx
+++ b/src/components/charts/BlockerPyramid.tsx
@@ -152,13 +152,13 @@ export default function BlockerPyramid({
           <p className="font-semibold text-gray-900">{tooltip.item.keyword}</p>
           <p className="mt-1 text-gray-500">언급 횟수: {tooltip.item.count}</p>
           <p className="text-gray-500">언급 인원 수: {tooltip.item.mentionedBy}</p>
-          {tooltip.item.memberNames && tooltip.item.memberNames.length > 0 && (
+          {tooltip.item.relatedMembers && tooltip.item.relatedMembers.length > 0 && (
             <div className="mt-2 max-w-[220px]">
               <p className="mb-1 font-medium text-gray-700">언급 팀원</p>
               <div className="flex flex-wrap gap-1">
-                {tooltip.item.memberNames.map((member) => (
-                  <span key={member} className="rounded-full bg-gray-50 px-2 py-0.5 text-gray-500">
-                    {member}
+                {tooltip.item.relatedMembers.map((member) => (
+                  <span key={member.memberId} className="rounded-full bg-gray-50 px-2 py-0.5 text-gray-500">
+                    {member.memberName}
                   </span>
                 ))}
               </div>

--- a/src/data/mockBlockerPyramid.ts
+++ b/src/data/mockBlockerPyramid.ts
@@ -2,16 +2,16 @@ import type { BlockerPyramidData } from '@/types/blocker';
 
 export const MOCK_BLOCKER_PYRAMID: BlockerPyramidData = {
   blockerKeywords: [
-    { keyword: 'QA 리소스 부족', count: 12, mentionedBy: 5 },
-    { keyword: '프론트엔드 소통 지연', count: 10, mentionedBy: 4 },
-    { keyword: '코드 리뷰 병목', count: 9, mentionedBy: 4 },
-    { keyword: '기획 변경 잦음', count: 8, mentionedBy: 3 },
-    { keyword: 'API 스펙 불명확', count: 7, mentionedBy: 3 },
-    { keyword: '배포 일정 압박', count: 6, mentionedBy: 3 },
-    { keyword: '의사결정 지연', count: 5, mentionedBy: 2 },
-    { keyword: '테스트 환경 불안정', count: 4, mentionedBy: 2 },
-    { keyword: '문서 최신화 부족', count: 3, mentionedBy: 2 },
-    { keyword: '회의 피로도', count: 2, mentionedBy: 1 },
+    { keyword: 'QA 리소스 부족', count: 12, mentionedBy: 5, relatedMembers: [{ memberId: 1, memberName: '김지수', mentionCount: 4 }, { memberId: 2, memberName: '이민준', mentionCount: 3 }] },
+    { keyword: '프론트엔드 소통 지연', count: 10, mentionedBy: 4, relatedMembers: [{ memberId: 3, memberName: '박서연', mentionCount: 3 }] },
+    { keyword: '코드 리뷰 병목', count: 9, mentionedBy: 4, relatedMembers: [{ memberId: 1, memberName: '김지수', mentionCount: 2 }] },
+    { keyword: '기획 변경 잦음', count: 8, mentionedBy: 3, relatedMembers: [] },
+    { keyword: 'API 스펙 불명확', count: 7, mentionedBy: 3, relatedMembers: [] },
+    { keyword: '배포 일정 압박', count: 6, mentionedBy: 3, relatedMembers: [] },
+    { keyword: '의사결정 지연', count: 5, mentionedBy: 2, relatedMembers: [] },
+    { keyword: '테스트 환경 불안정', count: 4, mentionedBy: 2, relatedMembers: [] },
+    { keyword: '문서 최신화 부족', count: 3, mentionedBy: 2, relatedMembers: [] },
+    { keyword: '회의 피로도', count: 2, mentionedBy: 1, relatedMembers: [] },
   ],
   actionPrescriptions: [
     {

--- a/src/types/blocker.ts
+++ b/src/types/blocker.ts
@@ -1,8 +1,15 @@
+export interface RelatedMember {
+  memberId: number;
+  memberName: string;
+  mentionCount: number;
+}
+
 export interface BlockerPyramidItem {
   keyword: string;
   count: number;
   mentionedBy: number;
-  memberNames?: string[];
+  relatedMembers?: RelatedMember[];
+  actionGuide?: string;
 }
 
 export interface BlockerActionPrescription {


### PR DESCRIPTION
## 문제
BE가 relatedMembers: [{id, name, count}] 형태로 응답하고 있으나
FE 타입이 mentionedMembers: string[] 로 선언되어 있어
언급 팀원 이름이 렌더링되지 않는 문제

## 변경 사항
- types/blocker.ts: RelatedMember 인터페이스 추가, BlockerPyramidItem에 relatedMembers/actionGuide 필드 추가 (mentionedMembers 제거)
- components/blocker/BlockerDetailCard.tsx: mentionedMembers → relatedMembers로 렌더링 수정
- data/mockBlockerPyramid.ts: 목 데이터 새 타입에 맞게 업데이트