### PR TITLE
feat: show health trend delta + status note, fix misleading 안정 label

### DIFF
--- a/src/components/feedback/TeamHealthScoreCard.tsx
+++ b/src/components/feedback/TeamHealthScoreCard.tsx
@@ -27,17 +27,37 @@ export default function TeamHealthScoreCard({ data, coachingSlot }: TeamHealthSc
   const score = Math.round(data.teamHealthScore);
   const alerts = data.alerts ?? [];
   const hasAlerts = alerts.length > 0;
+  const delta = data.trendDelta;
+  const hasDelta = typeof delta === 'number';
+  const deltaStyle =
+    !hasDelta || delta === 0
+      ? 'bg-gray-100 text-gray-500'
+      : delta > 0
+        ? 'bg-emerald-50 text-emerald-600'
+        : 'bg-red-50 text-red-500';
+  const deltaText = !hasDelta
+    ? ''
+    : delta > 0
+      ? `▲${delta}`
+      : delta < 0
+        ? `▼${Math.abs(delta)}`
+        : '≈';
 
   return (
     <Card className="mb-5 p-5">
       <div className="flex flex-col gap-5">
         <div className="min-w-0">
           <p className="text-base font-semibold text-gray-700">Team Health Score</p>
-          <div className="mt-3 flex items-end gap-2">
+          <div className="mt-3 flex flex-wrap items-end gap-2">
             <span className="text-5xl font-bold leading-none text-gray-950">
               {score}
             </span>
             <span className="pb-1 text-base font-medium text-gray-400">/100</span>
+            {hasDelta && (
+              <span className={`mb-1 rounded-full px-2 py-0.5 text-xs font-semibold ${deltaStyle}`}>
+                {deltaText} <span className="font-normal">최근 3개월 평균 대비</span>
+              </span>
+            )}
           </div>
           <div className="mt-3 h-1.5 w-full max-w-[33%] min-w-[180px] overflow-hidden rounded-full bg-gray-100">
             <div
@@ -48,9 +68,13 @@ export default function TeamHealthScoreCard({ data, coachingSlot }: TeamHealthSc
               }}
             />
           </div>
-          <p className={`mt-3 text-sm font-semibold ${trendMessageStyles[data.trend]}`}>
-            현재 추세는 {trendLabels[data.trend]} 상태입니다.
-          </p>
+          {data.statusNote ? (
+            <p className="mt-3 text-sm font-medium leading-relaxed text-gray-600">{data.statusNote}</p>
+          ) : (
+            <p className={`mt-3 text-sm font-semibold ${trendMessageStyles[data.trend]}`}>
+              현재 추세는 {trendLabels[data.trend]} 상태입니다.
+            </p>
+          )}
         </div>
 
         {coachingSlot && (

--- a/src/types/teamHealth.ts
+++ b/src/types/teamHealth.ts
@@ -5,4 +5,6 @@ export interface TeamHealthScoreData {
   teamHealthScore: number;
   trend: TeamHealthTrend;
   alerts: string[];
+  trendDelta?: number | null;
+  statusNote?: string | null;
 }


### PR DESCRIPTION
The card said "현재 추세는 안정 상태입니다" on a 36/100 score because that was the month-over-month trend (STABLE), read as "team is healthy."

Replace that line with the BE statusNote explaining why the score is at its level, and add a delta pill ("최근 3개월 평균 대비 ▲/▼") next to the score. Falls back to the old trend line when statusNote is absent.