### PR TITLE
feat: add leader growth page and promise reminder banner

### DIFF
--- a/src/api/leader.ts
+++ b/src/api/leader.ts
@@ -1,0 +1,8 @@
+import apiClient from './client';
+import type { ApiResponse } from './types';
+import type { LeaderGrowthData } from '@/types/leaderGrowth';
+
+export async function fetchLeaderGrowth(): Promise<LeaderGrowthData> {
+  const res = await apiClient.get<ApiResponse<LeaderGrowthData>>('/api/v1/leaders/me/growth');
+  return res.data.data;
+}

--- a/src/api/promises.ts
+++ b/src/api/promises.ts
@@ -1,6 +1,6 @@
 import apiClient from './client';
 import type { ApiResponse } from './types';
-import type { MemberPromiseSummary, OverduePromise } from '@/types/promise';
+import type { MemberPromiseSummary, OverduePromise, PromiseReminderData } from '@/types/promise';
 
 export async function fetchOverduePromises(memberId?: number | string): Promise<OverduePromise[]> {
   const res = await apiClient.get<ApiResponse<OverduePromise[]>>('/api/v1/promises/overdue', {
@@ -19,4 +19,9 @@ export async function fetchPromiseSummary(teamId: string): Promise<MemberPromise
 
 export async function completePromise(promiseId: string): Promise<void> {
   await apiClient.patch(`/api/v1/promises/${promiseId}/complete`);
+}
+
+export async function fetchPromiseReminders(): Promise<PromiseReminderData> {
+  const res = await apiClient.get<ApiResponse<PromiseReminderData>>('/api/v1/promises/reminders');
+  return res.data.data;
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -6,6 +6,7 @@ import LeaderDashboard from '@/pages/leader/LeaderDashboard';
 import MeetingsPage from '@/pages/leader/MeetingsPage';
 import LeaderMeetingDetailPage from '@/pages/leader/MeetingDetailPage';
 import LeaderMemberDetailPage from '@/pages/leader/LeaderMemberDetailPage';
+import LeaderGrowthPage from '@/pages/leader/LeaderGrowthPage';
 import PromiseLedgerPage from '@/pages/leader/PromiseLedgerPage';
 import TeamSetupPage from '@/pages/leader/TeamSetupPage';
 import MemberDashboard from '@/pages/member/MemberDashboard';
@@ -25,6 +26,7 @@ const router = createBrowserRouter([
   { path: '/leader/meetings', element: <RequiresTeam><MeetingsPage /></RequiresTeam> },
   { path: '/leader/meeting/:meetingId', element: <RequiresTeam><LeaderMeetingDetailPage /></RequiresTeam> },
   { path: '/leader/member/:memberId', element: <RequiresTeam><LeaderMemberDetailPage /></RequiresTeam> },
+  { path: '/leader/growth', element: <RequiresTeam><LeaderGrowthPage /></RequiresTeam> },
   { path: '/leader/promises', element: <RequiresTeam><PromiseLedgerPage /></RequiresTeam> },
   { path: '/leader/reports', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },
   { path: '/leader/overview', element: <RequiresTeam><LeaderDashboard /></RequiresTeam> },

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -29,6 +29,13 @@ const BarChartIcon = () => (
   </svg>
 );
 
+const TrendingUpIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+    <polyline points="17 6 23 6 23 12" />
+  </svg>
+);
+
 const SettingsIcon = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
     <circle cx="12" cy="12" r="3" />
@@ -56,6 +63,7 @@ const LogoutIcon = () => (
 const navItems: NavItem[] = [
   { label: '1on1 미팅', path: '/leader/meetings', icon: <CalendarIcon /> },
   { label: '팀 인사이트 대시보드', path: '/leader/dashboard', icon: <BarChartIcon /> },
+  { label: '나의 리더십 성장', path: '/leader/growth', icon: <TrendingUpIcon /> },
 ];
 
 const bottomItems = [
@@ -129,14 +137,16 @@ export default function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
     });
   };
 
-  const roleNavItems = navItems.map((item) => {
-    if (user?.role !== 'member') return item;
-    if (item.path === '/leader/meetings') return { ...item, path: '/member/meetings' };
-    if (item.path === '/leader/dashboard') {
-      return { ...item, label: '나의 커리어 메모리', path: '/member/dashboard' };
-    }
-    return item;
-  });
+  const roleNavItems = navItems
+    .filter((item) => user?.role !== 'member' || item.path !== '/leader/growth')
+    .map((item) => {
+      if (user?.role !== 'member') return item;
+      if (item.path === '/leader/meetings') return { ...item, path: '/member/meetings' };
+      if (item.path === '/leader/dashboard') {
+        return { ...item, label: '나의 커리어 메모리', path: '/member/dashboard' };
+      }
+      return item;
+    });
 
   const isMeetingActive =
     location.pathname === '/leader/meetings' ||

--- a/src/features/leader/useLeaderGrowth.ts
+++ b/src/features/leader/useLeaderGrowth.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { fetchLeaderGrowth } from '@/api/leader';
+import type { LeaderGrowthData } from '@/types/leaderGrowth';
+
+export function useLeaderGrowth() {
+  const [data, setData] = useState<LeaderGrowthData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchLeaderGrowth();
+        if (!ignore) setData(result);
+      } catch {
+        if (!ignore) {
+          setData(null);
+          setError('리더십 성장 데이터를 불러오지 못했습니다.');
+        }
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+
+    load();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/src/features/leader/usePromiseReminders.ts
+++ b/src/features/leader/usePromiseReminders.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { fetchPromiseReminders } from '@/api/promises';
+import type { PromiseReminderData } from '@/types/promise';
+
+export function usePromiseReminders() {
+  const [data, setData] = useState<PromiseReminderData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function load() {
+      try {
+        const result = await fetchPromiseReminders();
+        if (!ignore) setData(result);
+      } catch {
+        // 리마인더는 보조 정보 — 실패 시 배너를 표시하지 않음
+        if (!ignore) setData(null);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+
+    load();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return { data, loading };
+}

--- a/src/pages/leader/LeaderDashboard.tsx
+++ b/src/pages/leader/LeaderDashboard.tsx
@@ -13,6 +13,7 @@ import { useTeamHealthScore } from '@/features/leader/useTeamHealthScore';
 import { useTalkRatioRanking } from '@/features/leader/useTalkRatioRanking';
 import PromiseSummaryCard from '@/components/report/PromiseSummaryCard';
 import { usePromiseSummary } from '@/features/leader/usePromiseSummary';
+import { usePromiseReminders } from '@/features/leader/usePromiseReminders';
 import { useAuthStore } from '@/stores/authStore';
 import TeamCoachingCard from '@/components/feedback/TeamCoachingCard';
 import { useTeamCoaching } from '@/features/leader/useTeamCoaching';
@@ -50,6 +51,54 @@ function CommRow({ item }: { item: CommunicationBalance }) {
       </div>
       <Badge label={item.status} color={badgeColor} />
     </div>
+  );
+}
+
+// ── Promise Reminder Banner ────────────────────────────────────────────────────
+
+function PromiseReminderBanner() {
+  const { data, loading } = usePromiseReminders();
+  if (loading || !data) return null;
+  const { overdue, dueSoon } = data;
+  if (overdue.length === 0 && dueSoon.length === 0) return null;
+
+  return (
+    <Card className="mb-5 border border-amber-200 bg-amber-50 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-semibold text-amber-900">
+          약속 리마인더
+          {overdue.length > 0 && ` — 기한 초과 ${overdue.length}건`}
+          {dueSoon.length > 0 && ` · 마감 임박 ${dueSoon.length}건`}
+        </p>
+        <span className="flex-shrink-0 text-xs text-amber-700">
+          미이행 약속은 다음 미팅 브리핑에 자동 반영됩니다
+        </span>
+      </div>
+      <ul className="mt-2.5 flex flex-col gap-1.5">
+        {overdue.map((item) => (
+          <li key={item.promiseId} className="flex items-center gap-2 text-sm">
+            <span className="flex-shrink-0 rounded bg-red-100 px-1.5 py-0.5 text-[11px] font-semibold text-red-600">
+              {-item.daysLeft}일 지남
+            </span>
+            <span className="truncate text-gray-800">{item.content}</span>
+            <span className="flex-shrink-0 text-xs text-gray-400">
+              {item.memberName} · {item.dueDate}
+            </span>
+          </li>
+        ))}
+        {dueSoon.map((item) => (
+          <li key={item.promiseId} className="flex items-center gap-2 text-sm">
+            <span className="flex-shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[11px] font-semibold text-amber-700">
+              D-{item.daysLeft}
+            </span>
+            <span className="truncate text-gray-800">{item.content}</span>
+            <span className="flex-shrink-0 text-xs text-gray-400">
+              {item.memberName} · {item.dueDate}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Card>
   );
 }
 
@@ -120,6 +169,8 @@ export default function LeaderDashboard() {
       <div className="p-6 max-w-[1400px] mx-auto">
         {/* Page Title */}
         <h1 className="text-xl font-bold text-gray-900 mb-5">팀 인사이트 대시보드</h1>
+
+        <PromiseReminderBanner />
 
         {teamHealthLoading && (
           <Card className="mb-5 p-5">

--- a/src/pages/leader/LeaderGrowthPage.tsx
+++ b/src/pages/leader/LeaderGrowthPage.tsx
@@ -1,0 +1,191 @@
+import PageLayout from '@/components/layout/PageLayout';
+import Card from '@/components/ui/Card';
+import Skeleton from '@/components/ui/Skeleton';
+import { useLeaderGrowth } from '@/features/leader/useLeaderGrowth';
+import type { MonthlyTrendPoint } from '@/types/leaderGrowth';
+
+const RECOMMENDED_LEADER_RATIO = 40;
+
+function formatMonth(month: string) {
+  const [year, m] = month.split('-');
+  return `${year.slice(2)}.${m}`;
+}
+
+function ratioBarColor(value: number) {
+  if (value >= 70) return 'bg-red-400';
+  if (value >= 50) return 'bg-amber-400';
+  return 'bg-teal-400';
+}
+
+// ── 월별 추이 바 차트 (공용) ───────────────────────────────────────────────
+
+function TrendRows({
+  points,
+  unit,
+  colorOf,
+}: {
+  points: MonthlyTrendPoint[];
+  unit: string;
+  colorOf: (value: number) => string;
+}) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      {points.map((p) => (
+        <div key={p.month} className="flex items-center gap-3">
+          <span className="w-12 flex-shrink-0 text-xs font-medium text-gray-500">
+            {formatMonth(p.month)}
+          </span>
+          <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+            <div
+              className={`h-full rounded-full transition-all ${colorOf(p.value)}`}
+              style={{ width: `${Math.min(p.value, 100)}%` }}
+            />
+          </div>
+          <span className="w-14 flex-shrink-0 text-right text-sm font-semibold text-gray-800">
+            {p.value}
+            {unit}
+          </span>
+          <span className="w-10 flex-shrink-0 text-right text-[11px] text-gray-400">
+            {p.meetingCount}회
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TrendEmpty({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-[120px] items-center justify-center">
+      <p className="text-sm font-medium text-gray-400">{message}</p>
+    </div>
+  );
+}
+
+// ── 페이지 ─────────────────────────────────────────────────────────────────
+
+export default function LeaderGrowthPage() {
+  const { data, loading, error } = useLeaderGrowth();
+
+  return (
+    <PageLayout>
+      <div className="mx-auto max-w-[960px] p-6">
+        <h1 className="text-xl font-bold text-gray-900">나의 리더십 성장</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          최근 6개월간 1on1 미팅에서 실제로 관찰된 기록으로 집계한 변화입니다.
+        </p>
+
+        {loading && (
+          <div className="mt-5 flex flex-col gap-4">
+            <Skeleton className="h-20 rounded-lg" />
+            <div className="grid gap-4 lg:grid-cols-2">
+              <Skeleton className="h-48 rounded-lg" />
+              <Skeleton className="h-48 rounded-lg" />
+            </div>
+          </div>
+        )}
+
+        {!loading && error && (
+          <Card className="mt-5 p-5">
+            <p className="text-sm font-medium text-gray-400">{error}</p>
+          </Card>
+        )}
+
+        {!loading && !error && data && (
+          <div className="mt-5 flex flex-col gap-4">
+            {/* 하이라이트 */}
+            {data.highlights.length > 0 && (
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {data.highlights.map((h) => (
+                  <Card key={h} className="p-4">
+                    <p className="text-sm font-semibold leading-relaxed text-gray-800">{h}</p>
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              {/* 발화 비율 추이 */}
+              <Card className="p-5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  내 발화 비율 추이
+                </p>
+                <p className="mt-1 text-xs text-gray-400">
+                  월별 평균 리더 발화 비율 — 권장 {RECOMMENDED_LEADER_RATIO}% 이하
+                </p>
+                <div className="mt-4">
+                  {data.talkRatioTrend.length > 0 ? (
+                    <TrendRows
+                      points={data.talkRatioTrend}
+                      unit="%"
+                      colorOf={ratioBarColor}
+                    />
+                  ) : (
+                    <TrendEmpty message="아직 발화 비율이 측정된 미팅이 없습니다." />
+                  )}
+                </div>
+              </Card>
+
+              {/* 팀 안전감 신호 추이 */}
+              <Card className="p-5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  팀 안전감 신호 추이
+                </p>
+                <p className="mt-1 text-xs text-gray-400">
+                  내가 진행한 1on1에서 관찰된 팀원들의 솔직한 발화 신호 (월별 평균)
+                </p>
+                <div className="mt-4">
+                  {data.teamSafetyTrend.length > 0 ? (
+                    <TrendRows
+                      points={data.teamSafetyTrend}
+                      unit="점"
+                      colorOf={() => 'bg-indigo-400'}
+                    />
+                  ) : (
+                    <TrendEmpty message="아직 분석 완료된 미팅이 없습니다." />
+                  )}
+                </div>
+              </Card>
+            </div>
+
+            {/* 약속 이행 통계 */}
+            <Card className="p-5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                내 약속 이행
+              </p>
+              <p className="mt-1 text-xs text-gray-400">
+                1on1에서 팀원에게 약속한 항목의 이행 현황 — 약속을 지키는 리더가 솔직한 대화를 만듭니다.
+              </p>
+              {data.promiseStats.total > 0 ? (
+                <div className="mt-4 flex items-end gap-8">
+                  <div>
+                    <p className="text-3xl font-bold text-gray-900">
+                      {Math.round(data.promiseStats.doneRate)}%
+                    </p>
+                    <p className="mt-0.5 text-xs text-gray-400">이행률</p>
+                  </div>
+                  <div className="flex gap-6 pb-1">
+                    <div>
+                      <p className="text-lg font-semibold text-teal-600">{data.promiseStats.done}</p>
+                      <p className="text-xs text-gray-400">이행</p>
+                    </div>
+                    <div>
+                      <p className="text-lg font-semibold text-gray-700">{data.promiseStats.pending}</p>
+                      <p className="text-xs text-gray-400">대기</p>
+                    </div>
+                    <div>
+                      <p className="text-lg font-semibold text-red-500">{data.promiseStats.missed}</p>
+                      <p className="text-xs text-gray-400">미이행</p>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <TrendEmpty message="아직 등록한 약속이 없습니다." />
+              )}
+            </Card>
+          </div>
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/types/leaderGrowth.ts
+++ b/src/types/leaderGrowth.ts
@@ -1,0 +1,20 @@
+export interface MonthlyTrendPoint {
+  month: string; // 'YYYY-MM'
+  value: number;
+  meetingCount: number;
+}
+
+export interface LeaderPromiseStats {
+  total: number;
+  done: number;
+  missed: number;
+  pending: number;
+  doneRate: number; // 0~100, 소수점 1자리
+}
+
+export interface LeaderGrowthData {
+  talkRatioTrend: MonthlyTrendPoint[];
+  teamSafetyTrend: MonthlyTrendPoint[];
+  promiseStats: LeaderPromiseStats;
+  highlights: string[];
+}

--- a/src/types/promise.ts
+++ b/src/types/promise.ts
@@ -45,3 +45,17 @@ export interface MemberPromiseSummary {
     overdue: number
   }
 }
+
+export interface PromiseReminderItem {
+  promiseId: number
+  content: string
+  dueDate: string
+  daysLeft: number
+  memberName: string
+  meetingTitle: string
+}
+
+export interface PromiseReminderData {
+  overdue: PromiseReminderItem[]
+  dueSoon: PromiseReminderItem[]
+}


### PR DESCRIPTION
- /leader/growth: monthly talk ratio trend, team safety signal trend, promise fulfillment stats, fact-based highlight cards
- Sidebar nav item (leader only)
- LeaderDashboard: promise reminder banner (overdue / due-soon promises with auto-briefing note); hidden when empty or on fetch failure