### PR TITLE
 fix: 멤버 검색 필터 안전 접근 및 녹음 파일 업로드 조건 수정

### DIFF
--- a/src/components/ui/CreateMeetingModal.tsx
+++ b/src/components/ui/CreateMeetingModal.tsx
@@ -75,7 +75,7 @@ export default function CreateMeetingModal({ isOpen, onClose, onCreated }: Props
   }, [isOpen, user?.teamId]);
 
   const filtered = members.filter(
-    (m) => String(m.id) !== user?.id && (m.name.includes(search) || m.jobTitle.includes(search))
+    (m) => String(m.id) !== user?.id && (m.name?.includes(search) || m.jobTitle?.includes(search))
   );
 
   const calDays = useMemo(() => {

--- a/src/pages/leader/MeetingDetailPage.tsx
+++ b/src/pages/leader/MeetingDetailPage.tsx
@@ -234,9 +234,9 @@ export default function MeetingDetailPage() {
               >
                 1on1 미팅 시작하기
               </button>
-              {import.meta.env.VITE_SKIP_RECORDING === 'true' && surveyDone && (
+              {surveyDone && (
                 <label className="mt-2 cursor-pointer px-6 py-2 rounded-full border border-dashed border-gray-400 text-sm text-gray-500 hover:border-[#5F74FA] hover:text-[#5F74FA] transition-colors">
-                  [테스트] 파일 선택해서 업로드
+                  파일 선택해서 업로드
                   <input
                     type="file"
                     accept="audio/*,.webm"


### PR DESCRIPTION
변경 사항:
- CreateMeetingModal에서 멤버 name/jobTitle이 undefined일 때 필터 오류 방지 (옵셔널 체이닝 적용)
- MeetingDetailPage에서 파일 업로드 버튼 표시 조건에서 VITE_SKIP_RECORDING env 제거 → 멤버 사전 서베이 완료 시 항상 표시

동작 방식:
- 멤버 생성 시 name 또는 jobTitle이 없더라도 미팅 생성 모달 검색이 정상 동작
- .env 설정 없이도 리더 화면에서 사전 서베이 완료 후 녹음 파일 업로드 버튼 노출

테스트 포인트:
- [ ] 미팅 생성 모달에서 멤버 검색 시 오류 없이 필터링되는지 확인
- [ ] 사전 서베이 완료된 멤버의 미팅 상세 화면에서 파일 업로드 버튼 표시 확인
- [ ] VITE_SKIP_RECORDING 없는 환경(.env 미설정)에서도 동작 확인
